### PR TITLE
chore: test_artifacts/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ firestore-tests/node_modules/
 firestore-debug.log
 firebase-debug.log
 
+# 実機検証の証跡（スクリーンショット・UI dump）。ローカル保持のみ
+test_artifacts/
+
 # Keys / secrets
 *.keystore
 *.jks


### PR DESCRIPTION
実機/エミュレータ検証時のスクリーンショット・UI dump（39ファイル・6.1MB）が未追跡のまま On branch chore/ignore-test-artifacts
Your branch is up to date with 'origin/chore/ignore-test-artifacts'.

nothing to commit, working tree clean に残り続けていたため、無視対象に追加します。

検証の証跡としてローカルには残します（削除はしません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)