### PR TITLE
fix: 認証を有効化しFirestore同期を機能させる

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/MainActivity.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/MainActivity.kt
@@ -34,10 +34,8 @@ class MainActivity : AppCompatActivity() {
         val navInflater = navHostFragment.navController.navInflater
         val graph = navInflater.inflate(R.navigation.nav_graph)
 
-        // TODO: Firebase Console で Web Client ID を設定後に認証を有効化する
-        // 現在は google-services.json に Web Client ID 未登録のため認証をスキップし
-        // S-02 ホームを開始画面にする（認証有効化時: currentUser == null なら loginFragment）
-        graph.setStartDestination(R.id.homeFragment)
+        val isLoggedIn = FirebaseAuth.getInstance().currentUser != null
+        graph.setStartDestination(resolveStartDestinationId(isLoggedIn))
 
         navController = navHostFragment.navController
         navController.graph = graph
@@ -61,6 +59,16 @@ class MainActivity : AppCompatActivity() {
             val statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.statusBars())
             view.updatePadding(top = statusBarInsets.top)
             insets
+        }
+    }
+
+    companion object {
+        /**
+         * ログイン状態に応じて nav_graph の startDestination を決定する。
+         * 未ログインなら S-01 ログイン画面、ログイン済みなら S-02 ホームを開始画面にする。
+         */
+        fun resolveStartDestinationId(isLoggedIn: Boolean): Int {
+            return if (isLoggedIn) R.id.homeFragment else R.id.loginFragment
         }
     }
 }

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/auth/LoginFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/auth/LoginFragment.kt
@@ -60,10 +60,8 @@ class LoginFragment : Fragment() {
     }
 
     private fun setupGoogleSignIn() {
-        // TODO: google-services.json に client_type:3 の oauth_client を追加し、
-        //       Firebase Console で Web Client ID を設定すること。
-        //       現在 google-services.json に Web Client ID が未登録のため空文字を使用。
-        val webClientId = "735205368933-ndisk3lrvmgicvss0nfonv3o80nnavll.apps.googleusercontent.com"
+        // google-services.json の client_type:3 oauth_client から生成される Web Client ID を使用する
+        val webClientId = getString(R.string.default_web_client_id)
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(webClientId)
             .requestEmail()

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/navigation/NavGraphRegressionTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/navigation/NavGraphRegressionTest.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.Navigator
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
+import com.rokusoudo.healthcheckup.MainActivity
 import com.rokusoudo.healthcheckup.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -48,7 +49,24 @@ class NavGraphRegressionTest {
     }
 
     @Test
-    fun `開始画面はホーム(S-02)である`() {
+    fun `未ログイン状態の開始画面はログイン(S-01)である`() {
+        val startDestinationId = MainActivity.resolveStartDestinationId(isLoggedIn = false)
+        assertEquals(R.id.loginFragment, startDestinationId)
+
+        val graph = navController.navInflater.inflate(R.navigation.nav_graph)
+        graph.setStartDestination(startDestinationId)
+        navController.setGraph(graph, null)
+        assertEquals(R.id.loginFragment, currentId())
+    }
+
+    @Test
+    fun `ログイン済み状態の開始画面はホーム(S-02)である`() {
+        val startDestinationId = MainActivity.resolveStartDestinationId(isLoggedIn = true)
+        assertEquals(R.id.homeFragment, startDestinationId)
+
+        val graph = navController.navInflater.inflate(R.navigation.nav_graph)
+        graph.setStartDestination(startDestinationId)
+        navController.setGraph(graph, null)
         assertEquals(R.id.homeFragment, currentId())
     }
 


### PR DESCRIPTION
## Summary

Closes #7

Android アプリで認証が常時スキップされ、Firestore 同期が動作していなかった問題を修正します。

- `MainActivity`: `startDestination` を `FirebaseAuth.getInstance().currentUser` の有無に応じて動的に決定するよう変更（`resolveStartDestinationId(isLoggedIn: Boolean)` を追加し、未ログインなら `loginFragment`、ログイン済みなら `homeFragment`）。認証スキップの TODO コメントを削除
- `LoginFragment.setupGoogleSignIn()`: Web Client ID のハードコードを `google-services.json` 由来の `R.string.default_web_client_id` 参照に変更。実態と矛盾していた TODO コメントを削除
  - `google-services.json` には `client_type: 3` の oauth_client（`735205368933-ndisk3lrvmgicvss0nfonv3o80nnavll.apps.googleusercontent.com`）が既に登録済みであることを確認済み。値はハードコードされていたものと一致
  - `google-services` Gradle プラグインは既に適用済みのため `R.string.default_web_client_id` は自動生成される
- `NavGraphRegressionTest`: 静的な `startDestination` 前提だったテストを、`MainActivity.resolveStartDestinationId()` による動的決定ロジック（未ログイン→ログイン画面／ログイン済み→ホーム）を検証するテストに更新

### サインアウト導線について

Issue では「サインアウト導線が存在しない」とされていましたが、調査の結果 `menu_home.xml` の `action_sign_out` と `HomeFragment.signOut()`（`FirebaseAuth.signOut()` + Google Sign-In キャッシュクリア + `action_home_to_login` でホームをバックスタックから除去）は既に実装済みでした。`NavGraphRegressionTest` の「ログアウトでホームが除去されログイン成功でホームのみのスタックになる」テストも既存のまま変更していません。今回のPRでは変更していません。

### HealthRepository について

`syncRecordToFirestore()` / `upsertMaster()` / `restoreFromFirestore()` は既に `FirebaseAuth.getInstance().currentUser?.uid` を正しく参照する実装になっており、認証が有効化されれば正常に動作するため変更していません。

## Test plan

- [x] `./gradlew test` が全件パス（`NavGraphRegressionTest` は10件、全件成功）
- [ ] 実機/エミュレータでの手動確認（未ログイン→S-01表示、Google SSOログイン→S-02遷移＋`restoreFromFirestore`実行、再起動時にS-01を経由しない、手入力保存でFirestoreにドキュメント作成、項目マスター変更の同期、サインアウト→S-01復帰）は代表側でのご確認をお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)
