### PR TITLE
項目マスターの基準値変更時に既存記録の基準値外判定を再計算する

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/dao/ExaminationItemDao.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/dao/ExaminationItemDao.kt
@@ -3,6 +3,7 @@ package com.rokusoudo.healthcheckup.data.db.dao
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Update
 import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
 import kotlinx.coroutines.flow.Flow
 
@@ -11,6 +12,9 @@ interface ExaminationItemDao {
 
     @Insert
     suspend fun insertAll(items: List<ExaminationItem>)
+
+    @Update
+    suspend fun updateAll(items: List<ExaminationItem>)
 
     @Query("DELETE FROM examination_items WHERE recordId = :recordId")
     suspend fun deleteByRecordId(recordId: Long)
@@ -49,4 +53,10 @@ interface ExaminationItemDao {
      */
     @Query("SELECT recordId, COUNT(*) as count FROM examination_items WHERE isAbnormal = 1 GROUP BY recordId")
     fun getAbnormalCountsByRecord(): Flow<List<RecordAbnormalCount>>
+
+    /**
+     * 指定した項目名を持つ検査項目を全件取得する（項目マスター基準値変更時の再計算対象抽出用）。
+     */
+    @Query("SELECT * FROM examination_items WHERE itemName = :itemName")
+    suspend fun getByItemName(itemName: String): List<ExaminationItem>
 }

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/FirestoreRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/FirestoreRepository.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.tasks.await
  *
  * 薬事法対応: 保存・取得はデータの表示目的のみ。医療診断に使用しない。
  */
-class FirestoreRepository {
+class FirestoreRepository : HealthCloudSync {
 
     private val db: FirebaseFirestore = Firebase.firestore
 
@@ -30,7 +30,7 @@ class FirestoreRepository {
      * 診断記録をFirestoreに保存する。
      * ドキュメントID = Room の recordId（文字列）でクロスプラットフォーム同期を担保。
      */
-    suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
+    override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
         val data = mapOf(
             "date" to record.date,
             "facility" to record.facility,
@@ -53,7 +53,7 @@ class FirestoreRepository {
      * 項目マスターをFirestoreに保存する。
      * ドキュメントID = itemName。
      */
-    suspend fun saveItemMaster(uid: String, master: ItemMaster) {
+    override suspend fun saveItemMaster(uid: String, master: ItemMaster) {
         mastersRef(uid).document(master.itemName).set(
             mapOf(
                 "unit" to master.unit,
@@ -69,7 +69,7 @@ class FirestoreRepository {
     /**
      * Firestoreから全診断記録を取得する（他端末データ復元用）。
      */
-    suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> {
+    override suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> {
         val snapshot = recordsRef(uid).get().await()
         return snapshot.documents.mapNotNull { doc ->
             val id = doc.id.toLongOrNull() ?: return@mapNotNull null
@@ -99,7 +99,7 @@ class FirestoreRepository {
     /**
      * Firestoreから全項目マスターを取得する（他端末データ復元用）。
      */
-    suspend fun fetchItemMasters(uid: String): List<ItemMaster> {
+    override suspend fun fetchItemMasters(uid: String): List<ItemMaster> {
         val snapshot = mastersRef(uid).get().await()
         return snapshot.documents.mapNotNull { doc ->
             ItemMaster(

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthCloudSync.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthCloudSync.kt
@@ -1,0 +1,16 @@
+package com.rokusoudo.healthcheckup.data.repository
+
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+
+/**
+ * HealthRepository から見たクラウド同期先の抽象。
+ * 実装は FirestoreRepository。テストではフェイク実装に差し替え可能にするための境界。
+ */
+interface HealthCloudSync {
+    suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>)
+    suspend fun saveItemMaster(uid: String, master: ItemMaster)
+    suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>>
+    suspend fun fetchItemMasters(uid: String): List<ItemMaster>
+}

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
@@ -1,5 +1,6 @@
 package com.rokusoudo.healthcheckup.data.repository
 
+import androidx.room.withTransaction
 import com.google.firebase.auth.FirebaseAuth
 import com.rokusoudo.healthcheckup.OcrItem
 import com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase
@@ -13,10 +14,14 @@ import kotlinx.coroutines.flow.Flow
  * 健康診断データの Repository。
  * Room DB への読み書きと Cloud Firestore との同期を一元管理する。
  * 薬事法対応: isAbnormal は表示のみに使用し、医療診断を目的としない。
+ *
+ * @param currentUidProvider ログイン中ユーザーの uid 取得手段。既定は FirebaseAuth だが、
+ *   テストではフェイクの uid を返す関数に差し替え可能。
  */
 class HealthRepository(
     private val db: HealthCheckupDatabase,
-    private val firestoreRepository: FirestoreRepository
+    private val firestoreRepository: HealthCloudSync,
+    private val currentUidProvider: () -> String? = { FirebaseAuth.getInstance().currentUser?.uid }
 ) {
 
     /**
@@ -35,14 +40,6 @@ class HealthRepository(
 
         val examinationItems = items.map { ocrItem ->
             val master = db.masterDao().getByName(ocrItem.itemName)
-            val numericValue = ocrItem.value.toDoubleOrNull()
-            val isAbnormal = if (numericValue != null && master != null) {
-                val belowMin = master.referenceMin?.let { numericValue < it } ?: false
-                val aboveMax = master.referenceMax?.let { numericValue > it } ?: false
-                belowMin || aboveMax
-            } else {
-                false
-            }
             ExaminationItem(
                 recordId = recordId,
                 itemName = ocrItem.itemName,
@@ -50,7 +47,7 @@ class HealthRepository(
                 unit = ocrItem.unit,
                 referenceMin = master?.referenceMin,
                 referenceMax = master?.referenceMax,
-                isAbnormal = isAbnormal
+                isAbnormal = evaluateAbnormal(ocrItem.value, master?.referenceMin, master?.referenceMax)
             )
         }
         db.itemDao().insertAll(examinationItems)
@@ -62,7 +59,7 @@ class HealthRepository(
     }
 
     private suspend fun syncRecordToFirestore(record: ExaminationRecord, items: List<ExaminationItem>) {
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        val uid = currentUidProvider() ?: return
         try {
             firestoreRepository.saveRecord(uid, record, items)
         } catch (_: Exception) {
@@ -81,15 +78,56 @@ class HealthRepository(
 
     fun getAllMasters(): Flow<List<ItemMaster>> = db.masterDao().getAll()
 
-    // TODO: 項目マスターの基準値変更時、既存の ExaminationItem.isAbnormal は再計算されない。
-    // P1スコープ外のため対応保留（次回スプリントで対応予定）。
+    /**
+     * 項目マスターを更新する。
+     * 基準値（referenceMin / referenceMax）が実際に変化した場合のみ、
+     * 当該項目名の既存 ExaminationItem 全件を新基準で再計算する
+     * （カテゴリ変更・お気に入りトグルでは再計算しない＝不要な全件 UPDATE を避ける）。
+     * 再計算対象となった記録は Firestore にも再同期する。
+     */
     suspend fun upsertMaster(master: ItemMaster) {
-        db.masterDao().upsert(master)
+        val previous = db.masterDao().getByName(master.itemName)
+        val shouldRecalculate = referenceRangeChanged(previous, master)
+
+        val affectedRecordIds: List<Long> = if (shouldRecalculate) {
+            db.withTransaction {
+                db.masterDao().upsert(master)
+                val existingItems = db.itemDao().getByItemName(master.itemName)
+                val recalculated = existingItems.map { item ->
+                    item.copy(
+                        referenceMin = master.referenceMin,
+                        referenceMax = master.referenceMax,
+                        isAbnormal = evaluateAbnormal(item.value, master.referenceMin, master.referenceMax)
+                    )
+                }
+                if (recalculated.isNotEmpty()) {
+                    db.itemDao().updateAll(recalculated)
+                }
+                recalculated.map { it.recordId }.distinct()
+            }
+        } else {
+            db.masterDao().upsert(master)
+            emptyList()
+        }
+
         // 項目マスターもFirestoreへ同期
-        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+        val uid = currentUidProvider() ?: return
         try {
             firestoreRepository.saveItemMaster(uid, master)
-        } catch (_: Exception) {}
+        } catch (_: Exception) {
+            // オフライン時など同期失敗は無視
+        }
+
+        // 再計算対象の記録をFirestoreにも再同期し、Web版との整合を保つ
+        for (recordId in affectedRecordIds) {
+            val record = db.recordDao().getById(recordId) ?: continue
+            val itemsForRecord = db.itemDao().getByRecordIdOnce(recordId)
+            try {
+                firestoreRepository.saveRecord(uid, record, itemsForRecord)
+            } catch (_: Exception) {
+                // オフライン時など同期失敗は無視
+            }
+        }
     }
 
     /**
@@ -130,6 +168,30 @@ class HealthRepository(
             }
         } catch (_: Exception) {
             // ネットワーク不可時は無視（既存のローカルデータをそのまま使用）
+        }
+    }
+
+    companion object {
+        /**
+         * 検査値が基準値外かどうかを判定する。
+         * saveRecord() と upsertMaster() の再計算処理で共通利用する。
+         * 薬事法対応: 表示ハイライト用途のみで、医療的な合否判定ではない。
+         */
+        internal fun evaluateAbnormal(value: String?, min: Double?, max: Double?): Boolean {
+            val numericValue = value?.toDoubleOrNull() ?: return false
+            val belowMin = min?.let { numericValue < it } ?: false
+            val aboveMax = max?.let { numericValue > it } ?: false
+            return belowMin || aboveMax
+        }
+
+        /**
+         * 項目マスターの referenceMin / referenceMax が実際に変化したかどうかを判定する。
+         * カテゴリ変更・お気に入りトグルのみの更新では false を返し、
+         * ExaminationItem の不要な全件再計算・UPDATE を避ける。
+         */
+        internal fun referenceRangeChanged(previous: ItemMaster?, updated: ItemMaster): Boolean {
+            return previous?.referenceMin != updated.referenceMin ||
+                previous?.referenceMax != updated.referenceMax
         }
     }
 }

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/db/DaoRegressionTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/db/DaoRegressionTest.kt
@@ -102,6 +102,31 @@ class DaoRegressionTest {
     }
 
     @Test
+    fun `項目名指定で検査項目を全件取得できる`() = runBlocking {
+        insertRecordWithItems("2025-06-01", listOf(Triple("LDL", "150", false), Triple("HDL", "55", false)))
+        insertRecordWithItems("2024-06-01", listOf(Triple("LDL", "160", true)))
+
+        val items = db.itemDao().getByItemName("LDL")
+        assertEquals(2, items.size)
+        assertEquals(setOf("150", "160"), items.map { it.value }.toSet())
+    }
+
+    @Test
+    fun `updateAllで検査項目の基準値と判定を一括更新できる`() = runBlocking {
+        insertRecordWithItems("2025-06-01", listOf(Triple("LDL", "150", false)))
+        val items = db.itemDao().getByItemName("LDL")
+
+        db.itemDao().updateAll(
+            items.map { it.copy(referenceMin = null, referenceMax = 139.0, isAbnormal = true) }
+        )
+
+        val updated = db.itemDao().getByItemName("LDL")
+        assertEquals(1, updated.size)
+        assertEquals(139.0, updated[0].referenceMax!!, 0.0)
+        assertEquals(true, updated[0].isAbnormal)
+    }
+
+    @Test
     fun `項目マスターのupsertと取得ができる`() = runBlocking {
         db.masterDao().upsert(ItemMaster(itemName = "BMI", unit = "kg/m2", referenceMin = 18.5, referenceMax = 25.0))
         db.masterDao().upsert(ItemMaster(itemName = "BMI", unit = "kg/m2", referenceMin = 18.5, referenceMax = 24.9))

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryRecalcTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryRecalcTest.kt
@@ -1,0 +1,199 @@
+package com.rokusoudo.healthcheckup.data.repository
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #8: 項目マスターの基準値変更時、既存の ExaminationItem の isAbnormal 等が
+ * 再計算されること・不要な更新やFirestore再同期が起きないことを検証する。
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class HealthRepositoryRecalcTest {
+
+    private lateinit var db: HealthCheckupDatabase
+    private lateinit var cloudSync: FakeHealthCloudSync
+    private lateinit var repository: HealthRepository
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            HealthCheckupDatabase::class.java
+        ).allowMainThreadQueries().build()
+        cloudSync = FakeHealthCloudSync()
+        repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    private suspend fun insertRecordWithItem(
+        date: String,
+        itemName: String,
+        value: String,
+        referenceMin: Double?,
+        referenceMax: Double?,
+        isAbnormal: Boolean
+    ): Long {
+        val recordId = db.recordDao().insert(
+            ExaminationRecord(date = date, facility = "テスト病院", createdAt = 1000L)
+        )
+        db.itemDao().insertAll(
+            listOf(
+                ExaminationItem(
+                    recordId = recordId,
+                    itemName = itemName,
+                    value = value,
+                    unit = "mg/dL",
+                    referenceMin = referenceMin,
+                    referenceMax = referenceMax,
+                    isAbnormal = isAbnormal
+                )
+            )
+        )
+        return recordId
+    }
+
+    @Test
+    fun `基準値が変更されると既存レコードの基準値外判定が基準値内から基準値外に更新される`() = runBlocking {
+        db.masterDao().upsert(ItemMaster("LDL", "mg/dL", null, 160.0))
+        val recordId = insertRecordWithItem(
+            "2025-06-01", "LDL", "150", referenceMin = null, referenceMax = 160.0, isAbnormal = false
+        )
+
+        // 基準値を厳しくする（150は新基準では基準値外になる）
+        repository.upsertMaster(ItemMaster("LDL", "mg/dL", null, 139.0))
+
+        val items = db.itemDao().getByRecordIdOnce(recordId)
+        assertEquals(1, items.size)
+        assertTrue(items[0].isAbnormal)
+        assertEquals(139.0, items[0].referenceMax!!, 0.0)
+    }
+
+    @Test
+    fun `基準値が変更されると既存レコードの基準値外判定が基準値外から基準値内に更新される`() = runBlocking {
+        db.masterDao().upsert(ItemMaster("LDL", "mg/dL", null, 139.0))
+        val recordId = insertRecordWithItem(
+            "2025-06-01", "LDL", "150", referenceMin = null, referenceMax = 139.0, isAbnormal = true
+        )
+
+        // 基準値を緩める（150は新基準では基準値内になる）
+        repository.upsertMaster(ItemMaster("LDL", "mg/dL", null, 160.0))
+
+        val items = db.itemDao().getByRecordIdOnce(recordId)
+        assertEquals(1, items.size)
+        assertFalse(items[0].isAbnormal)
+        assertEquals(160.0, items[0].referenceMax!!, 0.0)
+    }
+
+    @Test
+    fun `お気に入りトグルのみでは既存レコードのisAbnormalは変化しない`() = runBlocking {
+        val original = ItemMaster("LDL", "mg/dL", null, 139.0, isFavorite = false)
+        db.masterDao().upsert(original)
+        val recordId = insertRecordWithItem(
+            "2025-06-01", "LDL", "150", referenceMin = null, referenceMax = 139.0, isAbnormal = true
+        )
+
+        repository.upsertMaster(original.copy(isFavorite = true, favoritedAt = 12345L))
+
+        val items = db.itemDao().getByRecordIdOnce(recordId)
+        assertEquals(1, items.size)
+        // 値・基準値外判定とも変化しないこと
+        assertTrue(items[0].isAbnormal)
+        assertEquals(139.0, items[0].referenceMax!!, 0.0)
+        // Firestoreへの記録再同期も発生しないこと（マスター同期のみ）
+        assertTrue(cloudSync.savedRecords.isEmpty())
+    }
+
+    @Test
+    fun `カテゴリ変更のみでは既存レコードのisAbnormalは変化しない`() = runBlocking {
+        val original = ItemMaster("LDL", "mg/dL", null, 139.0, category = "脂質")
+        db.masterDao().upsert(original)
+        val recordId = insertRecordWithItem(
+            "2025-06-01", "LDL", "120", referenceMin = null, referenceMax = 139.0, isAbnormal = false
+        )
+
+        repository.upsertMaster(original.copy(category = "その他"))
+
+        val items = db.itemDao().getByRecordIdOnce(recordId)
+        assertEquals(1, items.size)
+        assertFalse(items[0].isAbnormal)
+        assertEquals(139.0, items[0].referenceMax!!, 0.0)
+        assertTrue(cloudSync.savedRecords.isEmpty())
+    }
+
+    @Test
+    fun `再計算対象の記録はFirestoreにも再同期される`() = runBlocking {
+        db.masterDao().upsert(ItemMaster("LDL", "mg/dL", null, 160.0))
+        val recordId = insertRecordWithItem(
+            "2025-06-01", "LDL", "150", referenceMin = null, referenceMax = 160.0, isAbnormal = false
+        )
+
+        repository.upsertMaster(ItemMaster("LDL", "mg/dL", null, 139.0))
+
+        assertEquals(1, cloudSync.savedRecords.size)
+        val (syncedRecord, syncedItems) = cloudSync.savedRecords[0]
+        assertEquals(recordId, syncedRecord.id)
+        assertEquals(1, syncedItems.size)
+        assertTrue(syncedItems[0].isAbnormal)
+        // マスターの同期も呼ばれていること
+        assertEquals(1, cloudSync.savedMasters.size)
+    }
+
+    @Test
+    fun `evaluateAbnormalは最小値未満と最大値超過を基準値外と判定する`() {
+        assertTrue(HealthRepository.evaluateAbnormal("100", 120.0, null))
+        assertTrue(HealthRepository.evaluateAbnormal("200", null, 150.0))
+        assertFalse(HealthRepository.evaluateAbnormal("130", 120.0, 150.0))
+        assertFalse(HealthRepository.evaluateAbnormal(null, 120.0, 150.0))
+        assertFalse(HealthRepository.evaluateAbnormal("abc", 120.0, 150.0))
+    }
+
+    @Test
+    fun `referenceRangeChangedは基準値の変化のみを検知する`() {
+        val base = ItemMaster("LDL", "mg/dL", null, 139.0, category = "脂質", isFavorite = false)
+
+        assertFalse(HealthRepository.referenceRangeChanged(base, base.copy(isFavorite = true, favoritedAt = 1L)))
+        assertFalse(HealthRepository.referenceRangeChanged(base, base.copy(category = "その他")))
+        assertTrue(HealthRepository.referenceRangeChanged(base, base.copy(referenceMax = 150.0)))
+        assertTrue(HealthRepository.referenceRangeChanged(base, base.copy(referenceMin = 50.0)))
+        assertTrue(HealthRepository.referenceRangeChanged(null, base))
+        assertFalse(HealthRepository.referenceRangeChanged(null, base.copy(referenceMin = null, referenceMax = null)))
+    }
+
+    private class FakeHealthCloudSync : HealthCloudSync {
+        val savedRecords = mutableListOf<Pair<ExaminationRecord, List<ExaminationItem>>>()
+        val savedMasters = mutableListOf<ItemMaster>()
+
+        override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
+            savedRecords.add(record to items)
+        }
+
+        override suspend fun saveItemMaster(uid: String, master: ItemMaster) {
+            savedMasters.add(master)
+        }
+
+        override suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> =
+            emptyList()
+
+        override suspend fun fetchItemMasters(uid: String): List<ItemMaster> = emptyList()
+    }
+}


### PR DESCRIPTION
## 概要

項目マスターの基準値（`referenceMin` / `referenceMax`）を変更しても、既存の `ExaminationItem` の基準値外判定（`isAbnormal`）が再計算されない不整合を修正します。

Closes #8

## 変更内容

- `HealthRepository` の基準値外判定ロジックを `evaluateAbnormal(value, min, max)`（companion object, internal）として共通化し、`saveRecord()` / `upsertMaster()` の両方から使用するように変更
- `HealthRepository.upsertMaster()` に再計算処理を追加
  - `referenceRangeChanged(previous, updated)`（companion object, internal）で `referenceMin` / `referenceMax` が実際に変化したかを判定し、変化した場合のみ再計算する（カテゴリ変更・お気に入りトグルでは再計算しない）
  - 対象は当該 `itemName` の `ExaminationItem` 全件。最新マスター値で `referenceMin` / `referenceMax` / `isAbnormal` を上書き
  - マスターUPDATE + 項目再計算は `db.withTransaction { }` で1トランザクションにまとめ、途中失敗時の部分書き換えを防止
  - 再計算対象となった記録（recordId）は、記録全体を Firestore にも再同期（Web版との整合を保つ）
- `ExaminationItemDao` に `getByItemName()`（再計算対象抽出用）と `updateAll()`（`@Update`、一括更新用）を追加
- `HealthRepository.kt:84` の TODO コメントを削除
- `FirestoreRepository` をテスト可能にするため `HealthCloudSync` インターフェースを抽出し、`HealthRepository` の `firestoreRepository` フィールド型をこれに変更（`HealthCheckupApp.kt` の呼び出し側は変更不要）
- `HealthRepository` に `currentUidProvider: () -> String?` を追加（既定値は従来通り `FirebaseAuth.getInstance().currentUser?.uid`）。テストで実 Firebase を使わずに uid を注入できるようにするための差し替え口

## テスト

- `HealthRepositoryRecalcTest.kt`（新規、Robolectric + in-memory DB + フェイク `HealthCloudSync`）
  - 基準値変更で基準値内→基準値外になるケース
  - 基準値変更で基準値外→基準値内になるケース
  - お気に入りトグルのみでは `isAbnormal` が変化せず、Firestoreへの記録再同期も発生しないこと
  - カテゴリ変更のみでは `isAbnormal` が変化しないこと
  - 再計算対象の記録が Firestore に再同期されること（`saveRecord` 呼び出しの検証）
  - `evaluateAbnormal()` / `referenceRangeChanged()` の単体テスト
- `DaoRegressionTest.kt`（既存ファイルに追加）
  - `getByItemName()` で項目名指定の全件取得ができること
  - `updateAll()` で基準値・判定を一括更新できること

`./gradlew test` は全件パス（`BUILD SUCCESSFUL`）。

## 補足

- 「お気に入りトグル・カテゴリ変更でUPDATEが発生しないこと」については、モックライブラリ（Mockito/MockK等）がプロジェクトに未導入のため、呼び出し回数のスパイ検証ではなく、実 Room DB 上で値が変化しないこと（＋Firestore再同期が発生しないこと）を確認する形でテストしています。判定自体は `referenceRangeChanged()` の単体テストで直接検証済みです。
- 別Issue #7（`feature/issue-7-enable-auth-firestore-sync` / PR #10）とは無関係な `HealthRepository.kt` / `ExaminationItemDao.kt` / `FirestoreRepository.kt` 等のみを変更しており、#7 が触れている `MainActivity.kt` / `LoginFragment.kt` / `NavGraphRegressionTest.kt` には触れていません。
