### PR TITLE
fix: 認証状態に応じてstartDestinationを動的決定しFirestore同期を有効化

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/MainActivity.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/MainActivity.kt
@@ -34,10 +34,13 @@ class MainActivity : AppCompatActivity() {
         val navInflater = navHostFragment.navController.navInflater
         val graph = navInflater.inflate(R.navigation.nav_graph)
 
-        // TODO: Firebase Console で Web Client ID を設定後に認証を有効化する
-        // 現在は google-services.json に Web Client ID 未登録のため認証をスキップし
-        // S-02 ホームを開始画面にする（認証有効化時: currentUser == null なら loginFragment）
-        graph.setStartDestination(R.id.homeFragment)
+        // 未ログイン（currentUser == null）なら S-01 ログイン画面、ログイン済みなら S-02 ホームを開始画面にする
+        val startDestinationId = if (FirebaseAuth.getInstance().currentUser == null) {
+            R.id.loginFragment
+        } else {
+            R.id.homeFragment
+        }
+        graph.setStartDestination(startDestinationId)
 
         navController = navHostFragment.navController
         navController.graph = graph

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/auth/LoginFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/auth/LoginFragment.kt
@@ -60,12 +60,9 @@ class LoginFragment : Fragment() {
     }
 
     private fun setupGoogleSignIn() {
-        // TODO: google-services.json に client_type:3 の oauth_client を追加し、
-        //       Firebase Console で Web Client ID を設定すること。
-        //       現在 google-services.json に Web Client ID が未登録のため空文字を使用。
-        val webClientId = "735205368933-ndisk3lrvmgicvss0nfonv3o80nnavll.apps.googleusercontent.com"
+        // google-services.json の client_type:3 oauth_client から生成される Web Client ID を使用する
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestIdToken(webClientId)
+            .requestIdToken(getString(R.string.default_web_client_id))
             .requestEmail()
             .build()
         googleSignInClient = GoogleSignIn.getClient(requireActivity(), gso)

--- a/android/app/src/main/res/navigation/nav_graph.xml
+++ b/android/app/src/main/res/navigation/nav_graph.xml
@@ -4,7 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/homeFragment">
+    app:startDestination="@id/loginFragment">
 
     <!-- S-01 ログイン -->
     <fragment

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/navigation/NavGraphRegressionTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/navigation/NavGraphRegressionTest.kt
@@ -48,12 +48,22 @@ class NavGraphRegressionTest {
     }
 
     @Test
-    fun `開始画面はホーム(S-02)である`() {
+    fun `開始画面はログイン(S-01)である`() {
+        // MainActivity が未ログイン時に S-01 を開始画面として選ぶための安全なデフォルト（Issue #7）。
+        // ログイン済み時の S-02 開始は MainActivity 側で動的に上書きされるため、
+        // Fragment を起動しないこの nav_graph 単体テストの対象外（手動確認・PR本文に明記）。
+        assertEquals(R.id.loginFragment, currentId())
+    }
+
+    @Test
+    fun `ログインからホームへ遷移できる`() {
+        navController.navigate(R.id.action_login_to_home)
         assertEquals(R.id.homeFragment, currentId())
     }
 
     @Test
     fun `ホームから登録方法選択を経てカメラOCRフローに入り登録完了でホームへ戻る`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_register_method)
         assertEquals(R.id.registerMethodFragment, currentId())
         navController.navigate(R.id.action_register_method_to_camera)
@@ -67,6 +77,7 @@ class NavGraphRegressionTest {
 
     @Test
     fun `ホームから登録方法選択を経て手入力に入り登録完了でホームへ戻る`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_register_method)
         navController.navigate(R.id.action_register_method_to_manual_entry)
         assertEquals(R.id.manualEntryFragment, currentId())
@@ -77,6 +88,7 @@ class NavGraphRegressionTest {
 
     @Test
     fun `ホームから項目一覧を経て項目グラフへ遷移できる`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_item_list)
         assertEquals(R.id.itemListFragment, currentId())
         navController.navigate(R.id.action_item_list_to_trend_graph, bundleOf("itemName" to "BMI"))
@@ -85,12 +97,14 @@ class NavGraphRegressionTest {
 
     @Test
     fun `ホームからお問い合わせへ遷移できる`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_contact)
         assertEquals(R.id.contactFragment, currentId())
     }
 
     @Test
     fun `メニューから記録一覧と記録詳細とグラフの既存動線が維持される`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_record_list)
         assertEquals(R.id.mainFragment, currentId())
         navController.navigate(R.id.action_main_to_record_detail, bundleOf("recordId" to 1L))
@@ -101,6 +115,7 @@ class NavGraphRegressionTest {
 
     @Test
     fun `メニューから項目マスターと基準値外一覧へ遷移できる`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_item_master)
         assertEquals(R.id.itemMasterFragment, currentId())
 
@@ -111,6 +126,7 @@ class NavGraphRegressionTest {
 
     @Test
     fun `記録一覧のFABから登録方法選択へ遷移できる`() {
+        moveTo(R.id.homeFragment)
         navController.navigate(R.id.action_home_to_record_list)
         navController.navigate(R.id.action_main_to_register_method)
         assertEquals(R.id.registerMethodFragment, currentId())
@@ -118,6 +134,10 @@ class NavGraphRegressionTest {
 
     @Test
     fun `ログアウトでホームが除去されログイン成功でホームのみのスタックになる`() {
+        // 開始画面（loginFragment）から実際の遷移でホームへ入り、バックスタックを1件にしてから検証する
+        navController.navigate(R.id.action_login_to_home)
+        assertEquals(R.id.homeFragment, currentId())
+
         navController.navigate(R.id.action_home_to_login)
         assertEquals(R.id.loginFragment, currentId())
         assertFalse(navController.popBackStack())


### PR DESCRIPTION
## Summary

Closes #7

Android アプリで認証が常時スキップされ、Firestore 同期が動作していなかった問題を修正しました。

- **MainActivity.kt**: `startDestination` を `FirebaseAuth.getInstance().currentUser` に応じて動的に決定するよう変更（`null` → `loginFragment` / それ以外 → `homeFragment`）。古い TODO コメントを削除
- **LoginFragment.kt**: `setupGoogleSignIn()` のハードコードされた Web Client ID を `R.string.default_web_client_id`（`google-services.json` の `client_type: 3` oauth_client から自動生成される値）参照に変更。実態と矛盾していた TODO コメントを削除
  - `google-services.json` を確認したところ、既に `client_id: 735205368933-ndisk3lrvmgicvss0nfonv3o80nnavll.apps.googleusercontent.com` の `client_type: 3` oauth_client が登録済みで、これまでハードコードされていた値と完全一致していたため、対応は完了しています（未登録だった場合の代替対応は不要でした）
- **nav_graph.xml**: 宣言上の `app:startDestination` を安全側の `loginFragment` に変更（実行時は常に `MainActivity` が動的に上書きするため、実際のアプリ挙動への影響はなし。Robolectric テストなど `MainActivity` を経由しない経路でのデフォルトを安全側にする狙い）
- **NavGraphRegressionTest.kt**: 上記の nav_graph 変更に合わせてテストを更新
  - 開始画面を検証するテストを `loginFragment` を期待する内容に変更
  - `loginFragment → homeFragment` の遷移を検証するテストを追加
  - ホーム画面を起点とする各テストの先頭で `moveTo(R.id.homeFragment)` を呼び出すよう変更（これまでは nav_graph のデフォルト開始画面が `homeFragment` だったため不要だった）
  - ログアウト〜再ログインのテストは、`loginFragment` の開始画面から実際のナビゲーション（`action_login_to_home`）でホームへ入るように修正し、バックスタックの深さに依存する `assertFalse(popBackStack())` の検証が正しく成立するようにした

### サインアウト導線について

Issue 本文では「サインアウト導線が存在しない」とありましたが、調査したところ `menu_home.xml` の `action_sign_out` 項目と `HomeFragment.signOut()`（`FirebaseAuth.signOut()` + Google Sign-In キャッシュクリア + `action_home_to_login` 遷移）は既に実装済みでした。Issue 記述時点から状況が変わっていたとみられるため、本 PR ではこの部分の変更は行っていません。

## 確認できたこと（自動テスト）

- `./gradlew test` は全件成功（`NavGraphRegressionTest` を含む）

## 実機・エミュレータでの確認が必要なため未実施の項目（受け入れ基準より）

以下は Robolectric の単体テストでは検証できないため、実機/エミュレータでの手動確認が必要です:

- [ ] 未ログイン状態でアプリを起動すると S-01 ログイン画面が表示される
- [ ] Google SSO でログインすると S-02 ホームに遷移し、`restoreFromFirestore()` が実行されて他端末のデータが Room に復元される
- [ ] ログイン済み状態でアプリを再起動すると、ログイン画面を経由せず S-02 ホームが表示される
- [ ] ログイン後に S-06b 手入力で記録を保存すると、Firestore の `users/{uid}/records/{recordId}` にドキュメントが作成され、Web 版の記録一覧に同じ記録が表示される
- [ ] 項目マスターの基準値を変更すると `users/{uid}/itemMasters/{itemName}` に反映される
- [ ] ホームからサインアウトでき、サインアウト後は S-01 に戻る（実装はコードレベルで既に完了していることを確認済み。E2E での動作確認は未実施）

コードレベルでは実装ロジックとテストで担保していますが、Firebase Console 側の実設定（SHA-1 登録・Firestore ルールデプロイは Issue 本文で完了済みと記載）と実機での Google SSO フローそのものは、この環境では実行できないため確認できていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
