### PR TITLE
fix(ci): ダミー google-services.json に Web クライアントを追加し default_web_client_id を生成させる

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -19,6 +19,11 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       # google-services.json は秘匿のため未コミット。単体テスト用にダミーを生成する
+      #
+      # oauth_client に client_type: 3（Web）のエントリを必ず含めること。
+      # google-services Gradle プラグインは client_type: 3 が存在するときだけ
+      # R.string.default_web_client_id を生成するため、空配列にすると
+      # Google SSO のコード（LoginFragment）が Unresolved reference でコンパイルできない。
       - name: Provide dummy google-services.json
         run: |
           if [ ! -f android/app/google-services.json ]; then
@@ -35,9 +40,23 @@ jobs:
                   "mobilesdk_app_id": "1:000000000000:android:0000000000000000",
                   "android_client_info": { "package_name": "com.rokusoudo.healthcheckup" }
                 },
-                "oauth_client": [],
+                "oauth_client": [
+                  {
+                    "client_id": "000000000000-dummydummydummydummydummydummy00.apps.googleusercontent.com",
+                    "client_type": 3
+                  }
+                ],
                 "api_key": [{ "current_key": "AIzaDummyDummyDummyDummyDummyDummy000" }],
-                "services": { "appinvite_service": { "other_platform_oauth_client": [] } }
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": [
+                      {
+                        "client_id": "000000000000-dummydummydummydummydummydummy00.apps.googleusercontent.com",
+                        "client_type": 3
+                      }
+                    ]
+                  }
+                }
               }
             ],
             "configuration_version": "1"


### PR DESCRIPTION
## 背景

Issue #7 に対する PR #10 と PR #18 が、**どちらもまったく同じエラー**で CI に落ち続けていました。

```
e: .../ui/auth/LoginFragment.kt:65:48 Unresolved reference: default_web_client_id
> Task :app:compileDebugKotlin FAILED
```

原因は実装側ではなく **CI 側の設定**です。`android-test.yml` の「Provide dummy google-services.json」ステップが生成するダミー JSON は `"oauth_client": []` と空配列でした。google-services Gradle プラグインは `client_type: 3`（Web）のエントリが存在するときだけ `R.string.default_web_client_id` を生成するため、この参照が解決できません。

つまり「ハードコードした Web Client ID を `R.string.default_web_client_id` 参照に置き換える」という正しい修正を含む PR が、CI では必ず落ちる状態でした。

これにより #7 がマージできず open のまま残り、毎朝の `po-agent-daily-issue-check` が繰り返し #7 を拾って実装枠（1回最大2件）を消費し、#9・#12・#16・#17 が一度も着手されないという滞留が起きていました。

## 変更内容

ダミー `google-services.json` に `client_type: 3` のダミー Web クライアントを追加します。

- `client[0].oauth_client` に追加
- `client[0].services.appinvite_service.other_platform_oauth_client` にも同じ値を追加
- 値はすべてダミーで、実際の認証には使用されません（CI は単体テストのみを実行するため）
- 同じ轍を踏まないよう、空配列にしてはいけない理由をコメントで明記

## 検証

ローカルの分離した git worktree に、この変更後のワークフローからダミー JSON を生成（ワークフローの `run` スクリプトをそのまま抽出して実行）し、Gradle タスクを実行して確認しました。

```
$ ./gradlew :app:processDebugGoogleServices
$ grep -rn 'default_web_client_id' app/build/generated
app/build/generated/res/processDebugGoogleServices/values/values.xml:3:
  <string name="default_web_client_id" translatable="false">000000000000-dummy....apps.googleusercontent.com</string>
```

修正前は同じ手順でこのリソースが生成されないことも確認済みです。

なお本ブランチ自体の CI は、`LoginFragment` がまだハードコード値を使う main 断面のため修正前でもグリーンです。**実際の効果は PR #18 に main を取り込んで再実行したときに確認できます。**

## マージ後の手順

1. PR #18 のブランチに main を取り込む（または再実行する）
2. PR #18 の CI がグリーンになることを確認して #7 をマージする
3. 実装枠が空き、#12（OCR レイアウト解析）以降が自動実行で着手されるようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
