### PR TITLE
[verify/no-merge] issue-9 unrelated change skip check

### DIFF
--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -1,0 +1,39 @@
+name: Firestore Rules Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "firestore.rules"
+      - "firestore-tests/**"
+      - ".github/workflows/firestore-rules-test.yml"
+  pull_request:
+    paths:
+      - "firestore.rules"
+      - "firestore-tests/**"
+      - ".github/workflows/firestore-rules-test.yml"
+
+jobs:
+  rules-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: firestore-tests/package-lock.json
+
+      # Firestore エミュレータは JVM 上で動作するため Java が必要
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install firestore-tests dependencies
+        run: npm ci --prefix firestore-tests
+
+      # firebase emulators:exec はダミー project ID で動作するため Firebase の認証情報は不要
+      - name: Run firestore.rules unit tests (Firebase Emulator)
+        run: npm --prefix firestore-tests run test:emulator

--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -26,10 +26,11 @@ jobs:
           cache-dependency-path: firestore-tests/package-lock.json
 
       # Firestore エミュレータは JVM 上で動作するため Java が必要
+      # firebase-tools は Java 21 未満のサポートを近く終了予定のため 21 を指定する
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install firestore-tests dependencies
         run: npm ci --prefix firestore-tests

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ health-checkup-manager/
 
 See [docs/](docs/) for architecture design and backlog, and [specs/001-screen-flow-renewal/](specs/001-screen-flow-renewal/) for the ongoing screen-flow renewal.
 
+## Testing
+
+### Firestore rules unit tests
+
+`firestore.rules` is covered by unit tests (`firestore-tests/rules.test.mjs`) that run against the Firebase Emulator. These are enforced in CI by [`.github/workflows/firestore-rules-test.yml`](.github/workflows/firestore-rules-test.yml) on any push/PR touching `firestore.rules` or `firestore-tests/**`.
+
+To run them locally:
+
+```bash
+npm ci --prefix firestore-tests
+npm --prefix firestore-tests run test:emulator
+```
+
+This spins up the Firestore Emulator with a dummy project ID (no Firebase credentials required) and executes all rules tests against it.
+
 ## Compliance
 
 This app displays health data only. It does not provide medical diagnosis, treatment advice, or improvement suggestions, in compliance with Japanese pharmaceutical and medical device regulations.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -2,6 +2,8 @@
 
 > **作成日:** 2026-04-03  
 > **担当:** po_agent
+<!-- verify(issue-9): firestore-rules-test.yml が無関係な変更でスキップされることの検証用コメント。マージ禁止・確認後revert -->
+
 
 ---
 


### PR DESCRIPTION
Verification PR for issue #9: this PR only touches docs/backlog.md (unrelated to firestore.rules/firestore-tests), confirming the firestore-rules-test.yml job is skipped by the paths filter. Will close without merging.