### PR TITLE
ci: firestore.rules ユニットテストをCIで自動実行する

### DIFF
--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -1,0 +1,39 @@
+name: Firestore Rules Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "firestore.rules"
+      - "firestore-tests/**"
+      - ".github/workflows/firestore-rules-test.yml"
+  pull_request:
+    paths:
+      - "firestore.rules"
+      - "firestore-tests/**"
+      - ".github/workflows/firestore-rules-test.yml"
+
+jobs:
+  rules-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: firestore-tests/package-lock.json
+
+      # Firestore エミュレータは JVM 上で動作するため Java が必要
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install firestore-tests dependencies
+        run: npm ci --prefix firestore-tests
+
+      # firebase emulators:exec はダミー project ID で動作するため Firebase の認証情報は不要
+      - name: Run firestore.rules unit tests (Firebase Emulator)
+        run: npm --prefix firestore-tests run test:emulator

--- a/.github/workflows/firestore-rules-test.yml
+++ b/.github/workflows/firestore-rules-test.yml
@@ -26,10 +26,11 @@ jobs:
           cache-dependency-path: firestore-tests/package-lock.json
 
       # Firestore エミュレータは JVM 上で動作するため Java が必要
+      # firebase-tools は Java 21 未満のサポートを近く終了予定のため 21 を指定する
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "17"
+          java-version: "21"
 
       - name: Install firestore-tests dependencies
         run: npm ci --prefix firestore-tests

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ health-checkup-manager/
 
 See [docs/](docs/) for architecture design and backlog, and [specs/001-screen-flow-renewal/](specs/001-screen-flow-renewal/) for the ongoing screen-flow renewal.
 
+## Testing
+
+### Firestore rules unit tests
+
+`firestore.rules` is covered by unit tests (`firestore-tests/rules.test.mjs`) that run against the Firebase Emulator. These are enforced in CI by [`.github/workflows/firestore-rules-test.yml`](.github/workflows/firestore-rules-test.yml) on any push/PR touching `firestore.rules` or `firestore-tests/**`.
+
+To run them locally:
+
+```bash
+npm ci --prefix firestore-tests
+npm --prefix firestore-tests run test:emulator
+```
+
+This spins up the Firestore Emulator with a dummy project ID (no Firebase credentials required) and executes all rules tests against it.
+
 ## Compliance
 
 This app displays health data only. It does not provide medical diagnosis, treatment advice, or improvement suggestions, in compliance with Japanese pharmaceutical and medical device regulations.


### PR DESCRIPTION
## 背景

PR #5 で firestore.rules と Firebase Emulator ベースのルールユニットテスト（`firestore-tests/rules.test.mjs`、11件）を整備したが、CIで実行されておらず退行を検知できなかった (Issue #9)。

## 変更内容

- `.github/workflows/firestore-rules-test.yml` を新規追加（既存の `android-test.yml` は Android 専用のまま分離）
  - トリガー: `push`(main) / `pull_request`。`paths` を `firestore.rules` / `firestore-tests/**` / ワークフロー自身に限定
  - ステップ: `actions/checkout` → `actions/setup-node`(Node 20, `firestore-tests/package-lock.json` を使った npm キャッシュ) → `actions/setup-java`(Temurin 21) → `npm ci --prefix firestore-tests` → `npm --prefix firestore-tests run test:emulator`
  - Java は当初 17 を指定していたが、実測時のログで `firebase-tools` が Java 21 未満のサポートを近く終了する旨の警告が出たため 21 に変更した
  - シークレット追加は不要（エミュレータはダミー project ID で動作する既存スクリプトのまま）
- `README.md` に「Testing」節を追加し、ローカル実行手順（`npm ci --prefix firestore-tests && npm --prefix firestore-tests run test:emulator`）を記載

## 実測結果（本PR作成前に検証用ブランチ・PRで確認・削除済み）

1. **ルール退行時にジョブが落ちることの確認**
   `firestore.rules` の `request.auth.uid == uid` 条件を一時的に外した検証用ブランチ (`verify/issue-9-broken-rule`) で PR #21 を作成し、`Firestore Rules Tests` ジョブが実際に **failure** で終了することを確認した（11件中6件pass・5件fail、`Script "npm --prefix firestore-tests test" exited with code 1`）。確認後 PR はクローズ・ブランチは削除済み、`firestore.rules` は正しい状態に戻っている（今回のPRには含まれない）。
2. **無関係な変更のみのPRでスキップされることの確認**
   本ワークフローを含む状態のスクラッチベースブランチ (`verify/issue-9-base`) に対して `docs/backlog.md` のみを変更した子ブランチ (`verify/issue-9-unrelated-only`) で PR #23 を作成し、`Android Unit Tests` は起動する一方で `Firestore Rules Tests` は起動しない（`paths` フィルタでスキップされる）ことを確認した。確認後 PR はクローズ・スクラッチブランチは削除済み。

## 受け入れ基準

- [x] `.github/workflows/firestore-rules-test.yml` が追加され、`firestore.rules` を含む PR で自動実行される
- [x] 既存の 11 件のルールテストが CI 上で全件パスする（本PR自体のCI結果で確認）
- [x] `request.auth.uid == uid` 条件を外した状態で CI を回すとジョブが失敗することを確認済み（検証後に元へ戻し済み）
- [x] `firestore.rules` に無関係な変更のみの PR ではこのジョブがスキップされる
- [x] README にローカル実行方法を記載

Closes #9
