### PR TITLE
スキャンPDF・画像ファイルを取り込んでOCRする導線を追加する

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/CameraFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/CameraFragment.kt
@@ -2,6 +2,8 @@ package com.rokusoudo.healthcheckup
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -31,6 +33,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -42,8 +45,24 @@ class CameraFragment : Fragment() {
     private lateinit var cameraExecutor: ExecutorService
     private var imageCapture: ImageCapture? = null
 
-    // 撮影した画像プロキシのリスト（複数枚対応）
-    private val capturedImages: MutableList<ImageProxy> = mutableListOf()
+    /**
+     * OCR処理待ちの入力ソース（複数対応）。
+     * Issue #17: カメラ撮影に加え、SAFで選択したPDF（ページごとにBitmap化）・画像ファイルも
+     * 同じリストに積み、[startOcrProcessing] で共通処理する。
+     */
+    private sealed class OcrSource {
+        /** カメラ撮影（CameraX） */
+        data class Capture(val imageProxy: ImageProxy) : OcrSource()
+
+        /** SAFで選択したPDFのページをレンダリングしたBitmap */
+        data class ImportedBitmap(val bitmap: Bitmap) : OcrSource()
+
+        /** SAFで選択した画像ファイル（JPEG/PNG等）そのもの */
+        data class ImportedFile(val uri: Uri) : OcrSource()
+    }
+
+    // OCR処理待ちの入力ソース（複数枚対応。カメラ撮影・ファイル取り込みを問わない）
+    private val pendingSources: MutableList<OcrSource> = mutableListOf()
 
     // OCR処理用コルーチンスコープ
     private val ocrScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -64,6 +83,17 @@ class CameraFragment : Fragment() {
             }
         }
 
+    /**
+     * Issue #17: 保存済みPDF・画像ファイルの選択（Storage Access Framework）。
+     * `ActivityResultContracts.OpenDocument` はストレージ権限のリクエストを必要としない。
+     */
+    private val openDocumentLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri != null) {
+                importFile(uri)
+            }
+        }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -78,6 +108,7 @@ class CameraFragment : Fragment() {
         cameraExecutor = Executors.newSingleThreadExecutor()
 
         applyBottomControlsInsets()
+        applyTopControlsInsets()
 
         // パーミッション確認
         if (hasCameraPermission()) {
@@ -91,9 +122,14 @@ class CameraFragment : Fragment() {
         }
 
         binding.btnStartOcr.setOnClickListener {
-            if (capturedImages.isNotEmpty()) {
+            if (pendingSources.isNotEmpty()) {
                 startOcrProcessing()
             }
+        }
+
+        binding.btnImportFile.setOnClickListener {
+            // application/pdf と image/* を受付。ACTION_OPEN_DOCUMENT のためストレージ権限は不要。
+            openDocumentLauncher.launch(arrayOf("application/pdf", "image/*"))
         }
 
         updateCapturedCountUI()
@@ -108,6 +144,19 @@ class CameraFragment : Fragment() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.bottomControls) { view, insets ->
             val navBarInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
             view.updatePadding(bottom = initialBottomPadding + navBarInsets.bottom)
+            insets
+        }
+    }
+
+    /**
+     * targetSdk 35 の edge-to-edge 強制により「ファイルから読み込む」ボタン（[top_controls]）が
+     * ステータスバーに被るため、ステータスバー分を top padding に加算する。
+     */
+    private fun applyTopControlsInsets() {
+        val initialTopPadding = binding.topControls.paddingTop
+        ViewCompat.setOnApplyWindowInsetsListener(binding.topControls) { view, insets ->
+            val statusBarInsets = insets.getInsets(WindowInsetsCompat.Type.statusBars())
+            view.updatePadding(top = initialTopPadding + statusBarInsets.top)
             insets
         }
     }
@@ -155,9 +204,9 @@ class CameraFragment : Fragment() {
             ContextCompat.getMainExecutor(requireContext()),
             object : ImageCapture.OnImageCapturedCallback() {
                 override fun onCaptureSuccess(image: ImageProxy) {
-                    capturedImages.add(image)
+                    pendingSources.add(OcrSource.Capture(image))
                     updateCapturedCountUI()
-                    Log.d(TAG, "撮影成功: ${capturedImages.size}枚目")
+                    Log.d(TAG, "撮影成功: ${pendingSources.size}枚目")
                 }
 
                 override fun onError(exception: ImageCaptureException) {
@@ -168,26 +217,88 @@ class CameraFragment : Fragment() {
         )
     }
 
+    /**
+     * Issue #17: SAFで選択したファイルのMIMEタイプを判定し、PDFならページをBitmap化して、
+     * 画像ならそのまま [pendingSources] に積む。破損ファイル・パスワード付きPDF・
+     * 非対応形式はここでエラー分類してトースト表示し、クラッシュさせない。
+     */
+    private fun importFile(uri: Uri) {
+        val mimeType = requireContext().contentResolver.getType(uri)
+
+        if (!FileImportUtils.isSupportedMimeType(mimeType)) {
+            showImportError(FileImportUtils.FileImportError.UNSUPPORTED_FORMAT)
+            return
+        }
+
+        if (FileImportUtils.isPdfMimeType(mimeType)) {
+            importPdf(uri)
+        } else {
+            // 画像はIssue仕様どおり InputImage.fromFilePath() にそのまま渡すため、
+            // ここではUriを保持するだけでデコードは行わない。
+            pendingSources.add(OcrSource.ImportedFile(uri))
+            updateCapturedCountUI()
+        }
+    }
+
+    private fun importPdf(uri: Uri) {
+        ocrScope.launch {
+            try {
+                val bitmaps = withContext(Dispatchers.IO) {
+                    PdfPageRenderer.renderPages(requireContext(), uri)
+                }
+                withContext(Dispatchers.Main) {
+                    bitmaps.forEach { pendingSources.add(OcrSource.ImportedBitmap(it)) }
+                    updateCapturedCountUI()
+                }
+            } catch (e: FileImportException) {
+                Log.e(TAG, "PDF読み込みエラー", e)
+                withContext(Dispatchers.Main) { showImportError(e.error) }
+            } catch (e: Exception) {
+                Log.e(TAG, "PDF読み込みエラー", e)
+                withContext(Dispatchers.Main) {
+                    showImportError(FileImportUtils.classifyThrowable(e))
+                }
+            }
+        }
+    }
+
+    private fun showImportError(error: FileImportUtils.FileImportError) {
+        val messageRes = when (error) {
+            FileImportUtils.FileImportError.UNSUPPORTED_FORMAT -> R.string.error_import_unsupported_format
+            FileImportUtils.FileImportError.PASSWORD_PROTECTED -> R.string.error_import_password_protected
+            FileImportUtils.FileImportError.CORRUPTED_FILE -> R.string.error_import_corrupted_file
+            FileImportUtils.FileImportError.EMPTY_PDF -> R.string.error_import_empty_pdf
+            FileImportUtils.FileImportError.UNKNOWN -> R.string.error_import_unknown
+        }
+        Toast.makeText(requireContext(), getString(messageRes), Toast.LENGTH_LONG).show()
+    }
+
     private fun updateCapturedCountUI() {
-        val count = capturedImages.size
+        val count = pendingSources.size
         binding.tvCapturedCount.text = getString(R.string.label_captured_count, count)
         binding.btnStartOcr.visibility = if (count > 0) View.VISIBLE else View.GONE
         binding.btnStartOcr.text = getString(R.string.btn_start_ocr, count)
     }
 
     /**
-     * 撮影リスト内の全画像をML KitでOCR処理し、座標付きセル（[OcrCell]）に変換して
+     * 撮影・取り込み済みの全ソースをML KitでOCR処理し、座標付きセル（[OcrCell]）に変換して
      * OCR結果画面に遷移する。処理はIOディスパッチャで非同期実行。
      *
      * Issue #12: 行の文字列を空白区切りで解釈する方式では、健診結果表のように
      * 1行に複数の数値が並ぶ表形式を正しく解析できないため、ML Kit の
      * `boundingBox`（座標）を保持した [OcrCell] のリストを OcrResultFragment に渡し、
      * 座標ベースのレイアウト解析（[OcrParser]）に委ねる。
-     * 複数枚撮影時は画像ごとに座標系が独立するため、`page` にキャプチャ順のインデックスを持たせる。
+     * 複数枚撮影・複数ページ取り込み時はソースごとに座標系が独立するため、
+     * `page` に処理順のインデックスを持たせる。
+     *
+     * Issue #17: カメラ撮影（[OcrSource.Capture]）・PDFページ（[OcrSource.ImportedBitmap]）・
+     * 画像ファイル（[OcrSource.ImportedFile]）のいずれも、ここで [InputImage] に変換した後は
+     * 完全に同じ経路（ML Kit → [OcrAnalyzer] → OcrResultFragment）で処理する。
      */
     private fun startOcrProcessing() {
         binding.btnStartOcr.isEnabled = false
         binding.btnCapture.isEnabled = false
+        binding.btnImportFile.isEnabled = false
 
         ocrScope.launch {
             val combinedText = StringBuilder()
@@ -195,12 +306,16 @@ class CameraFragment : Fragment() {
             var totalBlocks = 0
             var totalLines = 0
 
-            capturedImages.forEachIndexed { pageIndex, imageProxy ->
+            pendingSources.forEachIndexed { pageIndex, source ->
                 try {
-                    val inputImage = InputImage.fromMediaImage(
-                        imageProxy.image!!,
-                        imageProxy.imageInfo.rotationDegrees
-                    )
+                    val inputImage = when (source) {
+                        is OcrSource.Capture -> InputImage.fromMediaImage(
+                            source.imageProxy.image!!,
+                            source.imageProxy.imageInfo.rotationDegrees
+                        )
+                        is OcrSource.ImportedBitmap -> InputImage.fromBitmap(source.bitmap, 0)
+                        is OcrSource.ImportedFile -> InputImage.fromFilePath(requireContext(), source.uri)
+                    }
                     val result = textRecognizer.process(inputImage).await()
 
                     totalBlocks += result.textBlocks.size
@@ -228,10 +343,10 @@ class CameraFragment : Fragment() {
                 } catch (e: Exception) {
                     Log.e(TAG, "OCR処理エラー", e)
                 } finally {
-                    imageProxy.close()
+                    releaseSource(source)
                 }
             }
-            capturedImages.clear()
+            pendingSources.clear()
 
             val ocrText = combinedText.toString().trim()
 
@@ -254,10 +369,19 @@ class CameraFragment : Fragment() {
         findNavController().navigate(action)
     }
 
+    /** [OcrSource] が保持するリソース（ImageProxy / Bitmap）を解放する。ImportedFileは解放不要。 */
+    private fun releaseSource(source: OcrSource) {
+        when (source) {
+            is OcrSource.Capture -> source.imageProxy.close()
+            is OcrSource.ImportedBitmap -> source.bitmap.recycle()
+            is OcrSource.ImportedFile -> Unit
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
-        capturedImages.forEach { it.close() }
-        capturedImages.clear()
+        pendingSources.forEach { releaseSource(it) }
+        pendingSources.clear()
         _binding = null
     }
 

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/FileImportUtils.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/FileImportUtils.kt
@@ -1,0 +1,62 @@
+package com.rokusoudo.healthcheckup
+
+import java.io.IOException
+
+/**
+ * Issue #17: ファイルからのOCR取り込み（PDF・画像）に関する MIME 判定・
+ * エラー分類ロジック。Android フレームワークに依存しない純粋なロジックとして切り出し、
+ * 単体テストできるようにする。
+ */
+object FileImportUtils {
+
+    /** ファイル取り込み時のエラー種別。薬事法対応: 医療アドバイスは含まない。 */
+    enum class FileImportError {
+        /** application/pdf でも image 系（image/ 始まり）でもない形式 */
+        UNSUPPORTED_FORMAT,
+
+        /** パスワード付きPDF（[android.graphics.pdf.PdfRenderer] は非対応） */
+        PASSWORD_PROTECTED,
+
+        /** ファイルが壊れている・読み込めない */
+        CORRUPTED_FILE,
+
+        /** PDFにページが1つも含まれない */
+        EMPTY_PDF,
+
+        /** 上記以外の予期しないエラー */
+        UNKNOWN
+    }
+
+    private const val MIME_PDF = "application/pdf"
+    private const val MIME_IMAGE_PREFIX = "image/"
+
+    fun isPdfMimeType(mimeType: String?): Boolean = mimeType == MIME_PDF
+
+    fun isImageMimeType(mimeType: String?): Boolean =
+        mimeType != null && mimeType.startsWith(MIME_IMAGE_PREFIX)
+
+    /** [ActivityResultContracts.OpenDocument] で選択可能にした2種別（PDF / 画像）か判定する。 */
+    fun isSupportedMimeType(mimeType: String?): Boolean =
+        isPdfMimeType(mimeType) || isImageMimeType(mimeType)
+
+    /**
+     * ファイルの読み込み・PDFレンダリング中に発生した例外を、UIに表示するための
+     * [FileImportError] に分類する。
+     *
+     * [android.graphics.pdf.PdfRenderer] はパスワード付きPDFに対して [SecurityException] を、
+     * 破損ファイルに対しては [IOException] を投げる（Android公式ドキュメント準拠）。
+     */
+    fun classifyThrowable(throwable: Throwable): FileImportError = when (throwable) {
+        is SecurityException -> FileImportError.PASSWORD_PROTECTED
+        is IOException -> FileImportError.CORRUPTED_FILE
+        is IllegalArgumentException -> FileImportError.CORRUPTED_FILE
+        is IllegalStateException -> FileImportError.CORRUPTED_FILE
+        else -> FileImportError.UNKNOWN
+    }
+}
+
+/** ファイル取り込み処理中に発生したエラーを、分類済みの [FileImportUtils.FileImportError] とともに表す例外。 */
+class FileImportException(
+    val error: FileImportUtils.FileImportError,
+    cause: Throwable? = null
+) : Exception(cause)

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/PdfPageRenderer.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/PdfPageRenderer.kt
@@ -1,0 +1,74 @@
+package com.rokusoudo.healthcheckup
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+
+/**
+ * Issue #17: Storage Access Framework で選択したPDFの各ページを、OCRにかけられる
+ * [Bitmap] にレンダリングする。
+ *
+ * 対象PDFはカメラでスキャンした画像PDFであり、テキストレイヤーを持たないため、
+ * テキスト直接抽出は行わずページを画像化してML KitのOCRにかける方式を採る。
+ *
+ * 複数ページPDFは、ページ選択UIを設けず全ページを [PdfRenderHelper.MAX_PAGE_COUNT] まで
+ * レンダリングして返す（呼び出し側でカメラ撮影と同様に全ページ分OCRし結果を統合する）。
+ */
+object PdfPageRenderer {
+
+    /**
+     * [uri] が指すPDFの各ページを [Bitmap] のリストとしてレンダリングする。
+     * 呼び出し側でIOディスパッチャ上から呼ぶこと（同期I/O・レンダリングを含むため）。
+     *
+     * @throws FileImportException 破損ファイル・パスワード付きPDF・ページ0件など、
+     *   ユーザーに提示すべきエラーが発生した場合
+     */
+    fun renderPages(context: Context, uri: Uri): List<Bitmap> {
+        val descriptor: ParcelFileDescriptor = try {
+            context.contentResolver.openFileDescriptor(uri, "r")
+                ?: throw FileImportException(FileImportUtils.FileImportError.CORRUPTED_FILE)
+        } catch (e: FileImportException) {
+            throw e
+        } catch (e: Exception) {
+            throw FileImportException(FileImportUtils.classifyThrowable(e), e)
+        }
+
+        descriptor.use { pfd ->
+            val renderer = try {
+                PdfRenderer(pfd)
+            } catch (e: Exception) {
+                throw FileImportException(FileImportUtils.classifyThrowable(e), e)
+            }
+
+            renderer.use { r ->
+                if (r.pageCount == 0) {
+                    throw FileImportException(FileImportUtils.FileImportError.EMPTY_PDF)
+                }
+
+                val pageCount = PdfRenderHelper.clampPageCount(r.pageCount)
+                return (0 until pageCount).map { index -> renderPage(r, index) }
+            }
+        }
+    }
+
+    private fun renderPage(renderer: PdfRenderer, index: Int): Bitmap {
+        try {
+            renderer.openPage(index).use { page ->
+                val (width, height) = PdfRenderHelper.renderSizeFor(page.width, page.height)
+                val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                // スキャンPDFは通常不透明な白背景のため、透過ピクセルによる誤認識を避けて
+                // 白で初期化してからレンダリングする。
+                bitmap.eraseColor(Color.WHITE)
+                page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                return bitmap
+            }
+        } catch (e: FileImportException) {
+            throw e
+        } catch (e: Exception) {
+            throw FileImportException(FileImportUtils.classifyThrowable(e), e)
+        }
+    }
+}

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/PdfRenderHelper.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/PdfRenderHelper.kt
@@ -1,0 +1,71 @@
+package com.rokusoudo.healthcheckup
+
+import kotlin.math.roundToInt
+
+/**
+ * Issue #17: PDFページを OCR にかけられる Bitmap にレンダリングする際の
+ * 解像度計算ロジック。[android.graphics.pdf.PdfRenderer] 自体を使わない
+ * 純粋なロジックとして切り出し、Robolectric 等の実機依存なしに単体テストできるようにする。
+ */
+object PdfRenderHelper {
+
+    /**
+     * OCR精度を確保するための目標解像度（dpi）。
+     * PDFページのサイズは pt（1/72インチ）単位のため、300dpi前後（一般的なスキャナ相当）を
+     * 基準に拡大してレンダリングしないと、健診表の細かい数値をML Kitが誤認識しやすくなる。
+     */
+    const val TARGET_DPI = 300
+
+    /**
+     * レンダリングするビットマップの1辺あたりの上限（px）。
+     * 極端に大きいページサイズ（例: ポスターサイズのPDF）をそのまま300dpiで
+     * レンダリングするとOOMの危険があるため、上限を超える場合はアスペクト比を保って縮小する。
+     */
+    const val MAX_DIMENSION_PX = 4000
+
+    /**
+     * 複数ページPDFで処理するページ数の上限。
+     * 上限なく全ページを処理すると、極端に多いページ数のPDFでOOM・処理時間の
+     * 増大を招くため上限を設ける（受け入れ基準の「複数ページのPDFが扱える」は
+     * 通常の健診結果PDF（数ページ程度）を想定しており、この上限で十分にカバーできる）。
+     */
+    const val MAX_PAGE_COUNT = 20
+
+    private const val POINTS_PER_INCH = 72f
+
+    /**
+     * PDFページのサイズ（pt。[android.graphics.pdf.PdfRenderer.Page.getWidth] /
+     * [android.graphics.pdf.PdfRenderer.Page.getHeight] と同じ単位）から、
+     * [targetDpi] を基準にレンダリングすべきビットマップの幅・高さ（px）を計算する。
+     *
+     * @throws IllegalArgumentException pageWidthPoints / pageHeightPoints が0以下の場合
+     */
+    fun renderSizeFor(
+        pageWidthPoints: Int,
+        pageHeightPoints: Int,
+        targetDpi: Int = TARGET_DPI
+    ): Pair<Int, Int> {
+        require(pageWidthPoints > 0 && pageHeightPoints > 0) {
+            "PDFページサイズは正の値である必要があります: width=$pageWidthPoints, height=$pageHeightPoints"
+        }
+
+        val scale = targetDpi / POINTS_PER_INCH
+        var width = (pageWidthPoints * scale).roundToInt()
+        var height = (pageHeightPoints * scale).roundToInt()
+
+        val largerSide = maxOf(width, height)
+        if (largerSide > MAX_DIMENSION_PX) {
+            val shrink = MAX_DIMENSION_PX.toFloat() / largerSide
+            width = (width * shrink).roundToInt()
+            height = (height * shrink).roundToInt()
+        }
+
+        return width.coerceAtLeast(1) to height.coerceAtLeast(1)
+    }
+
+    /**
+     * PDFの総ページ数のうち、実際に処理するページ数を [MAX_PAGE_COUNT] で切り詰めて返す。
+     */
+    fun clampPageCount(totalPageCount: Int): Int =
+        totalPageCount.coerceIn(0, MAX_PAGE_COUNT)
+}

--- a/android/app/src/main/res/layout/fragment_camera.xml
+++ b/android/app/src/main/res/layout/fragment_camera.xml
@@ -18,6 +18,30 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <!-- Issue #17: 保存済みPDF・画像ファイルからの取り込み導線（SAFのOpenDocumentを起動） -->
+    <LinearLayout
+        android:id="@+id/top_controls"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end|center_vertical"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_import_file"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/btn_import_file"
+            android:textColor="@color/white" />
+
+    </LinearLayout>
+
     <!-- Bottom controls bar -->
     <LinearLayout
         android:id="@+id/bottom_controls"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,14 @@
     <string name="btn_start_ocr">OCR開始 (%d枚)</string>
     <string name="label_captured_count">撮影済み: %d枚</string>
 
+    <!-- Camera screen: Issue #17 ファイル取り込み導線 -->
+    <string name="btn_import_file">📁 ファイルから読み込む</string>
+    <string name="error_import_unsupported_format">対応していないファイル形式です</string>
+    <string name="error_import_password_protected">パスワード付きのPDFは読み込めません</string>
+    <string name="error_import_corrupted_file">ファイルを読み込めませんでした。ファイルが破損している可能性があります</string>
+    <string name="error_import_empty_pdf">PDFにページが含まれていません</string>
+    <string name="error_import_unknown">ファイルの読み込み中にエラーが発生しました</string>
+
     <!-- OCR result screen -->
     <string name="title_ocr_result">OCR結果確認</string>
     <string name="hint_item_name">項目名</string>

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/FileImportUtilsTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/FileImportUtilsTest.kt
@@ -1,0 +1,99 @@
+package com.rokusoudo.healthcheckup
+
+import java.io.IOException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #17: FileImportUtils のテスト。
+ * SAFで選択したファイルのMIME判定と、PdfRenderer等が投げる例外の分類ロジックを検証する。
+ */
+class FileImportUtilsTest {
+
+    // ------------------------------------------------------------
+    // MIMEタイプ判定
+    // ------------------------------------------------------------
+
+    @Test
+    fun `application_pdfはPDFとして判定される`() {
+        assertTrue(FileImportUtils.isPdfMimeType("application/pdf"))
+        assertTrue(FileImportUtils.isSupportedMimeType("application/pdf"))
+    }
+
+    @Test
+    fun `image_で始まるMIMEタイプは画像として判定される`() {
+        assertTrue(FileImportUtils.isImageMimeType("image/jpeg"))
+        assertTrue(FileImportUtils.isImageMimeType("image/png"))
+        assertTrue(FileImportUtils.isSupportedMimeType("image/jpeg"))
+    }
+
+    @Test
+    fun `PDFでも画像でもないMIMEタイプは非対応と判定される`() {
+        assertFalse(FileImportUtils.isSupportedMimeType("text/plain"))
+        assertFalse(FileImportUtils.isSupportedMimeType("application/zip"))
+        assertFalse(FileImportUtils.isPdfMimeType("image/jpeg"))
+        assertFalse(FileImportUtils.isImageMimeType("application/pdf"))
+    }
+
+    @Test
+    fun `MIMEタイプがnullの場合は非対応と判定される`() {
+        assertFalse(FileImportUtils.isSupportedMimeType(null))
+        assertFalse(FileImportUtils.isPdfMimeType(null))
+        assertFalse(FileImportUtils.isImageMimeType(null))
+    }
+
+    // ------------------------------------------------------------
+    // 例外分類（PdfRenderer等が投げる例外 → ユーザー提示用エラー種別）
+    // ------------------------------------------------------------
+
+    @Test
+    fun `SecurityExceptionはパスワード付きPDFとして分類される`() {
+        assertEquals(
+            FileImportUtils.FileImportError.PASSWORD_PROTECTED,
+            FileImportUtils.classifyThrowable(SecurityException("password required"))
+        )
+    }
+
+    @Test
+    fun `IOExceptionは破損ファイルとして分類される`() {
+        assertEquals(
+            FileImportUtils.FileImportError.CORRUPTED_FILE,
+            FileImportUtils.classifyThrowable(IOException("damaged pdf"))
+        )
+    }
+
+    @Test
+    fun `IllegalArgumentExceptionとIllegalStateExceptionは破損ファイルとして分類される`() {
+        assertEquals(
+            FileImportUtils.FileImportError.CORRUPTED_FILE,
+            FileImportUtils.classifyThrowable(IllegalArgumentException("bad arg"))
+        )
+        assertEquals(
+            FileImportUtils.FileImportError.CORRUPTED_FILE,
+            FileImportUtils.classifyThrowable(IllegalStateException("bad state"))
+        )
+    }
+
+    @Test
+    fun `想定外の例外はUNKNOWNとして分類される`() {
+        assertEquals(
+            FileImportUtils.FileImportError.UNKNOWN,
+            FileImportUtils.classifyThrowable(RuntimeException("something else"))
+        )
+    }
+
+    // ------------------------------------------------------------
+    // FileImportException
+    // ------------------------------------------------------------
+
+    @Test
+    fun `FileImportExceptionはエラー種別と原因を保持する`() {
+        val cause = IOException("damaged")
+        val exception = FileImportException(FileImportUtils.FileImportError.CORRUPTED_FILE, cause)
+
+        assertEquals(FileImportUtils.FileImportError.CORRUPTED_FILE, exception.error)
+        assertEquals(cause, exception.cause)
+    }
+}

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/PdfRenderHelperTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/PdfRenderHelperTest.kt
@@ -1,0 +1,71 @@
+package com.rokusoudo.healthcheckup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Issue #17: PdfRenderHelper のテスト。
+ * PdfRenderer 自体には依存しない純粋なロジック（レンダリング解像度・ページ数の計算）を検証する。
+ */
+class PdfRenderHelperTest {
+
+    @Test
+    fun `A4サイズのページを300dpiでレンダリングすると想定どおりのpx数になる`() {
+        // A4 = 595 x 842 pt
+        val (width, height) = PdfRenderHelper.renderSizeFor(595, 842, targetDpi = 300)
+        // 595 / 72 * 300 = 2479.16... -> 2479
+        assertEquals(2479, width)
+        // 842 / 72 * 300 = 3508.33... -> 3508
+        assertEquals(3508, height)
+    }
+
+    @Test
+    fun `US Letterサイズのページを300dpiでレンダリングすると想定どおりのpx数になる`() {
+        // US Letter = 612 x 792 pt
+        val (width, height) = PdfRenderHelper.renderSizeFor(612, 792, targetDpi = 300)
+        assertEquals(2550, width)
+        assertEquals(3300, height)
+    }
+
+    @Test
+    fun `極端に大きいページサイズはMAX_DIMENSION_PXを超えないようアスペクト比を保って縮小される`() {
+        // 巨大なポスターサイズ想定 (2000pt x 1000pt) を高DPIでレンダリングすると
+        // 素の計算では上限を大きく超えるため、縮小されることを確認する。
+        val (width, height) = PdfRenderHelper.renderSizeFor(2000, 1000, targetDpi = 300)
+
+        assertTrue("width must not exceed MAX_DIMENSION_PX", width <= PdfRenderHelper.MAX_DIMENSION_PX)
+        assertTrue("height must not exceed MAX_DIMENSION_PX", height <= PdfRenderHelper.MAX_DIMENSION_PX)
+        // アスペクト比（2:1）が維持されていること
+        assertEquals(2.0, width.toDouble() / height.toDouble(), 0.01)
+        // 長辺がちょうど上限に張り付いていること
+        assertEquals(PdfRenderHelper.MAX_DIMENSION_PX, maxOf(width, height))
+    }
+
+    @Test
+    fun `ページサイズが0以下の場合は例外を投げる`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            PdfRenderHelper.renderSizeFor(0, 842)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            PdfRenderHelper.renderSizeFor(595, -1)
+        }
+    }
+
+    @Test
+    fun `ページ数が上限以下の場合はそのまま返す`() {
+        assertEquals(1, PdfRenderHelper.clampPageCount(1))
+        assertEquals(PdfRenderHelper.MAX_PAGE_COUNT, PdfRenderHelper.clampPageCount(PdfRenderHelper.MAX_PAGE_COUNT))
+    }
+
+    @Test
+    fun `ページ数が上限を超える場合は上限に切り詰められる`() {
+        assertEquals(PdfRenderHelper.MAX_PAGE_COUNT, PdfRenderHelper.clampPageCount(PdfRenderHelper.MAX_PAGE_COUNT + 50))
+    }
+
+    @Test
+    fun `ページ数が0の場合は0を返す`() {
+        assertEquals(0, PdfRenderHelper.clampPageCount(0))
+    }
+}


### PR DESCRIPTION
## Summary

Issue #17: 保存済みのPDF・画像ファイルを選択してOCRを実行できる導線を追加しました。従来はCameraFragmentのCameraXライブ撮影のみが入口で、健診結果のスキャン済みPDF・画像を取り込む手段がありませんでした。

- OCR実行画面（S-06a `CameraFragment`）に「ファイルから読み込む」ボタンを追加
- `ActivityResultContracts.OpenDocument` で `application/pdf` と `image/*` を受付（Storage Access Framework。ストレージ権限は不要）
- PDFは `android.graphics.pdf.PdfRenderer` でページを300dpi相当のBitmapにレンダリング（`PdfRenderHelper` / `PdfPageRenderer`）。極端に大きいページはOOM防止のため4000pxに丸め、複数ページPDFは最大20ページまで全ページをOCR対象にする（ページ選択UIは設けず、カメラ複数枚撮影と同様に全ページを結果へ統合する方式を採用）
- 画像ファイルは `InputImage.fromFilePath()` でそのままML Kitに渡す
- カメラ撮影（`ImageProxy`）・PDFページ（`Bitmap`）・画像ファイル（`Uri`）を `OcrSource` として統一し、`startOcrProcessing()` 以降（ML Kit呼び出し・`OcrAnalyzer`によるエラー評価・`OcrResultFragment`への遷移）はカメラ経路と完全に共通化
- 破損ファイル・パスワード付きPDF・非対応形式は `FileImportUtils.classifyThrowable` でエラー種別に分類し、トースト表示してクラッシュしないようにした（`SecurityException`→パスワード付きPDF、`IOException`等→破損ファイル）
- 追加UIは既存の `DESIGN.md` のトークン（既存カラー参照、タップ対象48dp以上）に準拠

## 変更ファイル

- `android/app/src/main/java/com/rokusoudo/healthcheckup/CameraFragment.kt`（ファイル選択導線・OcrSource統一・共通OCR処理への統合）
- `android/app/src/main/java/com/rokusoudo/healthcheckup/PdfRenderHelper.kt`（新規: レンダリング解像度・ページ数上限の純粋なロジック）
- `android/app/src/main/java/com/rokusoudo/healthcheckup/PdfPageRenderer.kt`（新規: PdfRendererを使った実際のページBitmap化）
- `android/app/src/main/java/com/rokusoudo/healthcheckup/FileImportUtils.kt`（新規: MIME判定・例外分類）
- `android/app/src/main/res/layout/fragment_camera.xml`（「ファイルから読み込む」ボタン追加）
- `android/app/src/main/res/values/strings.xml`（関連文言追加）

## 受け入れ基準の充足状況

- [x] OCR実行画面から、保存済みのPDFまたは画像ファイルを選択できる
- [x] ストレージ権限のリクエストなしにファイルを選択できる（`ActivityResultContracts.OpenDocument` = SAF）
- [x] 選択したPDFがページ画像にレンダリングされ、OCRが実行される
- [x] 複数ページのPDFが扱える（全ページを順にOCRし結果を統合。上限20ページ）
- [x] 選択した画像ファイル（JPEG / PNG）でOCRが実行される
- [x] OCR後の確認画面がカメラ経路と同一の処理を通る（`OcrSource`統一により`startOcrProcessing`以降は完全共通）
- [x] 破損ファイル・パスワード付きPDF・非対応形式を選択した場合にクラッシュせず、エラーが表示される（コードレベルで対応・単体テストで例外分類ロジックを検証。下記「未検証事項」参照）
- [x] 追加するUIは `DESIGN.md` のトークン・ルールに準拠（既存カラートークンを流用、タップ対象48dp以上、edge-to-edge対応のinset処理を追加）

## テスト

- `./gradlew :app:testDebugUnitTest` 全件成功（既存テスト含む）
- `./gradlew :app:assembleDebug` ビルド成功
- 新規ユニットテスト
  - `PdfRenderHelperTest`（レンダリング解像度計算・ページ数上限のクランプ・不正入力の例外）
  - `FileImportUtilsTest`（MIMEタイプ判定・例外分類）

## 未検証事項（実機・エミュレータでの動作確認は未実施）

- 実際のPDFファイル（複数ページ・パスワード付き・破損ファイル）を選択したときの `PdfRenderer` の実際の挙動（レンダリング結果の見た目・エラー発生パターン）は、Android実機/エミュレータでの確認ができていません。`PdfRenderer` 自体はAndroidフレームワーク依存のため、CIのJVMユニットテストでは検証できず、公式ドキュメントの例外仕様（パスワード付き→`SecurityException`、破損→`IOException`）に基づいてロジックを実装・分類しています
- SAFのファイルピッカーUIの実際の見た目・操作感（実機での「ファイルから読み込む」ボタンのタップしやすさ等）
- 大きいPDF（多ページ・高解像度）を実際に処理した際のメモリ使用量・処理時間

Closes #17
