### PR TITLE
fix(ocr): 検査日ヘッダー行を項目データから除外し検査日初期値に反映

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrParser.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrParser.kt
@@ -1,5 +1,6 @@
 package com.rokusoudo.healthcheckup
 
+import java.time.LocalDate
 import kotlin.math.abs
 
 /**
@@ -20,9 +21,18 @@ import kotlin.math.abs
  * 4. グリッドの各行を [OcrItem] に変換する（[rowToItem]）
  *
  * ## 列→項目のマッピング（暫定ルール）
- * 本Issueの担当範囲はグリッド復元までとする。ヘッダー行の除外・「今回」列の特定・
- * 項目名の正規化は別Issueで扱うため、現時点では「1列目を項目名、2列目を値」の
- * 暫定ルールで [OcrItem] に変換する。
+ * 「今回」列の特定・項目名の正規化は別Issueで扱うため、現時点では
+ * 「1列目を項目名、2列目を値」の暫定ルールで [OcrItem] に変換する。
+ *
+ * ## ヘッダー行の除外（Issue #13）
+ * 「今回 / 前回 / 前々回」のように複数列を持つ健診結果表は、先頭行に
+ * 検査日（例: 2025/8/22、R7.8.22）が列ごとに並ぶヘッダー行を持つことが多い。
+ * このヘッダー行を項目データとして取り込まないよう、行内で日付として解釈できる
+ * セルが2つ以上ある行を「ヘッダー行」と判定し、[OcrItem] への変換対象から除外する
+ * （[isHeaderRow]）。単一のセルがたまたま日付に見えるだけではヘッダー行と
+ * 判定しない（データ行の誤除外を避けるため）。
+ * ヘッダー行から取得できた検査日は捨てず、値として採用する列（暫定ルールの2列目）
+ * に対応する日付を [OcrParseResult.examDate] として呼び出し側に返す。
  *
  * ## 後方互換
  * 1行が単一セルのみで構成される場合（=旧方式のようにOCR行全体が1文字列のセルとして
@@ -41,17 +51,55 @@ object OcrParser {
     // 列クラスタリング: 同一列とみなす閾値 = 平均セル幅 × この係数
     private const val COLUMN_X_THRESHOLD_RATIO = 0.75
 
+    // 暫定ルール（Issue #12）: グリッドの2列目（インデックス1）を値として採用する。
+    // ヘッダー行から検査日を取り出す際も、同じ列に対応する日付を採用する。
+    private const val VALUE_COLUMN_INDEX = 1
+
+    // ヘッダー行判定: 行内でこの数以上のセルが日付として解釈できる場合にヘッダー行とみなす。
+    // 1（単一セル）だと、値がたまたま日付に見えるデータ行を誤って落としてしまうため2以上とする。
+    private const val HEADER_ROW_MIN_DATE_CELLS = 2
+
     /**
-     * 座標付きセルのリストを解析してOcrItemリストを返す。
+     * 座標付きセルのリストを解析してOcrItemリストを返す（後方互換API）。
+     * ヘッダー行から検出した検査日が必要な場合は [parseWithDate] を使用する。
      *
      * @param cells ML Kit の `Text.Element` 相当の「文字列 + boundingBox」のセルのリスト
      * @return 解析結果のリスト。全セルが空、またはグリッド復元結果が空の場合は
      *         空のOcrItem1件を返し手動入力を促す。
      */
-    fun parse(cells: List<OcrCell>): List<OcrItem> {
+    fun parse(cells: List<OcrCell>): List<OcrItem> = parseWithDate(cells).items
+
+    /**
+     * 座標付きセルのリストを解析し、[OcrItem] のリストとヘッダー行から検出した
+     * 検査日（取得できた場合）を返す（Issue #13）。
+     *
+     * - グリッドの各行についてヘッダー行判定（[isHeaderRow]）を行い、ヘッダー行は
+     *   [OcrItem] への変換対象から除外する。
+     * - ヘッダー行が複数ある場合は、最初に検査日を抽出できた行の値を採用する。
+     *
+     * @param cells ML Kit の `Text.Element` 相当の「文字列 + boundingBox」のセルのリスト
+     * @return items: 解析結果のリスト（ヘッダー行を除く）。空の場合は空のOcrItem1件。
+     *         examDate: ヘッダー行から取得した検査日（"YYYY-MM-DD"形式）。取得できなければnull。
+     */
+    fun parseWithDate(cells: List<OcrCell>): OcrParseResult {
         val grid = buildGrid(cells)
-        val results = grid.mapNotNull { row -> rowToItem(row) }
-        return results.ifEmpty { listOf(OcrItem("", "", "")) }
+
+        val items = mutableListOf<OcrItem>()
+        var examDate: String? = null
+        for (row in grid) {
+            if (isHeaderRow(row)) {
+                if (examDate == null) {
+                    examDate = extractExamDateFromHeaderRow(row)
+                }
+                continue
+            }
+            rowToItem(row)?.let { items.add(it) }
+        }
+
+        return OcrParseResult(
+            items = items.ifEmpty { listOf(OcrItem("", "", "")) },
+            examDate = examDate
+        )
     }
 
     /**
@@ -174,7 +222,7 @@ object OcrParser {
         }
 
         val itemName = row.getOrNull(0)?.trim().orEmpty()
-        val value = row.getOrNull(1)?.trim().orEmpty()
+        val value = row.getOrNull(VALUE_COLUMN_INDEX)?.trim().orEmpty()
         if (itemName.isBlank() && value.isBlank()) return null
 
         return OcrItem(itemName = itemName, value = value, unit = "")
@@ -190,6 +238,88 @@ object OcrParser {
         val (itemName, value, unit) = match.destructured
         return OcrItem(itemName = itemName, value = value, unit = unit)
     }
+
+    // ------------------------------------------------------------
+    // ヘッダー行判定・検査日抽出（Issue #13）
+    // ------------------------------------------------------------
+
+    /**
+     * 行内でこの数以上のセルが日付として解釈できる場合、その行をヘッダー行とみなす。
+     * 単一セルが日付に見えるだけではヘッダー行と判定しない
+     * （数値のみのデータ行を誤って除外しないため）。
+     */
+    private fun isHeaderRow(row: List<String>): Boolean {
+        val dateCellCount = row.count { parseDateCell(it) != null }
+        return dateCellCount >= HEADER_ROW_MIN_DATE_CELLS
+    }
+
+    /**
+     * ヘッダー行から、値として採用する列（[VALUE_COLUMN_INDEX]）に対応する検査日を取り出す。
+     * その列が日付として解釈できない場合はnullを返す（従来どおり手動入力に委ねる）。
+     *
+     * @return "YYYY-MM-DD" 形式の日付文字列。取得できなければnull。
+     */
+    private fun extractExamDateFromHeaderRow(row: List<String>): String? {
+        val valueColumnText = row.getOrNull(VALUE_COLUMN_INDEX) ?: return null
+        val date = parseDateCell(valueColumnText) ?: return null
+        return "%04d-%02d-%02d".format(date.year, date.monthValue, date.dayOfMonth)
+    }
+
+    // 西暦4桁（例: 2025/8/22, 2025-08-22, 2025.8.22）
+    private val SEIREKI_YEAR4_PATTERN = Regex("""^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$""")
+
+    // 西暦2桁（例: 25/8/22）。健診結果表は近年の日付のため 2000年代とみなす。
+    private val SEIREKI_YEAR2_PATTERN = Regex("""^(\d{2})[-/.](\d{1,2})[-/.](\d{1,2})$""")
+
+    // 和暦（例: R7.8.22, H31.4.1）。元号の頭文字（R/H/S/M）+ 年 + 区切り + 月 + 区切り + 日。
+    private val WAREKI_PATTERN = Regex("""^([RHSMrhsm])(\d{1,2})[-/.](\d{1,2})[-/.](\d{1,2})$""")
+
+    /**
+     * セルのテキストを日付として解釈できる場合は [LocalDate] を返す。
+     * 西暦4桁・西暦2桁・和暦（令和/平成/昭和/明治）の区切り文字違い（"/", "-", "."）に対応する。
+     * 解釈できない、または存在しない日付（例: 2月30日）の場合はnullを返す。
+     */
+    private fun parseDateCell(text: String): LocalDate? {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return null
+
+        parseWareki(trimmed)?.let { return it }
+        parseSeirekiYear4(trimmed)?.let { return it }
+        parseSeirekiYear2(trimmed)?.let { return it }
+        return null
+    }
+
+    private fun parseWareki(text: String): LocalDate? {
+        val match = WAREKI_PATTERN.matchEntire(text) ?: return null
+        val (era, warekiYearStr, monthStr, dayStr) = match.destructured
+        val seirekiYear = toSeirekiYear(era.uppercase()[0], warekiYearStr.toInt()) ?: return null
+        return toLocalDateOrNull(seirekiYear, monthStr.toInt(), dayStr.toInt())
+    }
+
+    private fun parseSeirekiYear4(text: String): LocalDate? {
+        val match = SEIREKI_YEAR4_PATTERN.matchEntire(text) ?: return null
+        val (yearStr, monthStr, dayStr) = match.destructured
+        return toLocalDateOrNull(yearStr.toInt(), monthStr.toInt(), dayStr.toInt())
+    }
+
+    private fun parseSeirekiYear2(text: String): LocalDate? {
+        val match = SEIREKI_YEAR2_PATTERN.matchEntire(text) ?: return null
+        val (yearStr, monthStr, dayStr) = match.destructured
+        return toLocalDateOrNull(2000 + yearStr.toInt(), monthStr.toInt(), dayStr.toInt())
+    }
+
+    /** 和暦の元号1文字と和暦年から西暦年を求める。未知の元号の場合はnull。 */
+    private fun toSeirekiYear(era: Char, warekiYear: Int): Int? = when (era) {
+        'R' -> 2018 + warekiYear // 令和1年 = 2019年
+        'H' -> 1988 + warekiYear // 平成1年 = 1989年
+        'S' -> 1925 + warekiYear // 昭和1年 = 1926年
+        'M' -> 1867 + warekiYear // 明治1年 = 1868年
+        else -> null
+    }
+
+    /** 実在しない日付（2月30日など）の場合はnullを返す。 */
+    private fun toLocalDateOrNull(year: Int, month: Int, day: Int): LocalDate? =
+        runCatching { LocalDate.of(year, month, day) }.getOrNull()
 }
 
 /**
@@ -203,4 +333,15 @@ data class OcrItem(
     val itemName: String,
     val value: String,
     val unit: String
+)
+
+/**
+ * [OcrParser.parseWithDate] の結果を表すデータクラス（Issue #13）。
+ *
+ * @param items    ヘッダー行を除いた [OcrItem] のリスト
+ * @param examDate ヘッダー行から取得した検査日（"YYYY-MM-DD"形式）。取得できなければnull。
+ */
+data class OcrParseResult(
+    val items: List<OcrItem>,
+    val examDate: String?
 )

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrResultFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrResultFragment.kt
@@ -35,6 +35,10 @@ class OcrResultFragment : Fragment() {
     private val args: OcrResultFragmentArgs by navArgs()
     private lateinit var ocrItemAdapter: OcrItemAdapter
 
+    // Issue #13: ヘッダー行（検査日が並ぶ行）から取得できた検査日。
+    // 取得できた場合は検査日入力ダイアログの初期値として使用する。取得できなければnull（従来どおり手動入力）。
+    private var detectedExamDate: String? = null
+
     private val viewModel: OcrResultViewModel by viewModels {
         val app = requireActivity().application as HealthCheckupApp
         OcrResultViewModel.Factory(app, app.repository)
@@ -93,7 +97,9 @@ class OcrResultFragment : Fragment() {
     }
 
     private fun setupRecyclerView(cells: List<OcrCell>) {
-        val items = OcrParser.parse(cells).toMutableList()
+        val parseResult = OcrParser.parseWithDate(cells)
+        detectedExamDate = parseResult.examDate
+        val items = parseResult.items.toMutableList()
         ocrItemAdapter = OcrItemAdapter(items)
 
         binding.recyclerOcrItems.apply {
@@ -115,6 +121,14 @@ class OcrResultFragment : Fragment() {
 
     private fun showDatePickerDialog() {
         val calendar = Calendar.getInstance()
+        // Issue #13: ヘッダー行から検査日が取得できていれば、検査日入力ダイアログの初期値に反映する。
+        // 取得できていない場合は従来どおり今日の日付が初期値になり、ユーザーが手動で選択する。
+        detectedExamDate?.let { dateString ->
+            runCatching {
+                val (year, month, day) = dateString.split("-").map { it.toInt() }
+                calendar.set(year, month - 1, day)
+            }
+        }
         DatePickerDialog(
             requireContext(),
             { _, year, month, dayOfMonth ->

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/OcrParserTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/OcrParserTest.kt
@@ -132,6 +132,115 @@ class OcrParserTest {
         )
     }
 
+    // ------------------------------------------------------------
+    // ヘッダー行の除外・検査日抽出（Issue #13）
+    // ------------------------------------------------------------
+
+    @Test
+    fun `西暦のヘッダー行は項目データとして抽出されず検査日として取得される`() {
+        // ヘッダー行: 項目名列は空、今回列z=1が2025/8/22、前回列z=2が2024/9/4、前々回列z=3が2023/4/5
+        val cells = listOf(
+            cell("2025/8/22", 200, 0, 260, 40),
+            cell("2024/9/4", 320, 0, 380, 40),
+            cell("2023/4/5", 440, 0, 500, 40),
+            cell("HbA1c", 0, 100, 100, 140),
+            cell("5.6", 200, 100, 240, 140),
+            cell("5.4", 320, 100, 360, 140),
+            cell("4.6-6.2", 440, 100, 540, 140)
+        )
+
+        val result = OcrParser.parseWithDate(cells)
+
+        assertEquals(listOf(OcrItem("HbA1c", "5.6", "")), result.items)
+        assertEquals("2025-08-22", result.examDate)
+
+        // 後方互換の parse() でも日付ヘッダー行は項目データに含まれない
+        assertEquals(listOf(OcrItem("HbA1c", "5.6", "")), OcrParser.parse(cells))
+    }
+
+    @Test
+    fun `和暦のヘッダー行から検査日が西暦に変換されて取得される`() {
+        // ヘッダー行: 今回列が R6.9.4（令和6年9月4日）、前回列が R7.8.22
+        val cells = listOf(
+            cell("R6.9.4", 200, 0, 260, 40),
+            cell("R7.8.22", 320, 0, 380, 40),
+            cell("体重", 0, 100, 100, 140),
+            cell("68.5", 200, 100, 240, 140),
+            cell("70.2", 320, 100, 380, 140)
+        )
+
+        val result = OcrParser.parseWithDate(cells)
+
+        assertEquals(listOf(OcrItem("体重", "68.5", "")), result.items)
+        assertEquals("2024-09-04", result.examDate)
+    }
+
+    @Test
+    fun `区切り文字がハイフンの検査日ヘッダー行も判定・変換される`() {
+        val cells = listOf(
+            cell("2025-08-22", 200, 0, 260, 40),
+            cell("2024-09-04", 320, 0, 380, 40),
+            cell("身長", 0, 100, 100, 140),
+            cell("172.5", 200, 100, 240, 140),
+            cell("171.0", 320, 100, 380, 140)
+        )
+
+        val result = OcrParser.parseWithDate(cells)
+
+        assertEquals(listOf(OcrItem("身長", "172.5", "")), result.items)
+        assertEquals("2025-08-22", result.examDate)
+    }
+
+    @Test
+    fun `検査日が取得できないヘッダー行なしの画像ではexamDateはnullで手動入力に委ねる`() {
+        val cells = listOf(
+            cell("HbA1c", 0, 0, 100, 40),
+            cell("5.6", 200, 0, 240, 40)
+        )
+
+        val result = OcrParser.parseWithDate(cells)
+
+        assertEquals(listOf(OcrItem("HbA1c", "5.6", "")), result.items)
+        assertEquals(null, result.examDate)
+    }
+
+    @Test
+    fun `単一セルのみが日付に見えるデータ行はヘッダー行と誤判定されず値として保持される`() {
+        // 「12/3/4」は西暦2桁パターンに偶然マッチしうるが、行内で日付らしいセルは1つだけなので
+        // ヘッダー行とは判定されず、データ行として通常どおり抽出される。
+        val headerCells = listOf(
+            cell("2025/8/22", 200, 0, 260, 40),
+            cell("2024/9/4", 320, 0, 380, 40)
+        )
+        val borderlineDataRow = listOf(
+            cell("血液型比", 0, 100, 100, 140),
+            cell("12/3/4", 200, 100, 260, 140),
+            cell("98", 320, 100, 360, 140)
+        )
+        val cells = headerCells + borderlineDataRow
+
+        val result = OcrParser.parseWithDate(cells)
+
+        assertEquals(listOf(OcrItem("血液型比", "12/3/4", "")), result.items)
+        assertEquals("2025-08-22", result.examDate)
+    }
+
+    @Test
+    fun `数値のみが並ぶデータ行はヘッダー行と誤判定されない`() {
+        // 血圧のような「今回/前回」に数値が並ぶだけの行が、日付ヘッダー行として
+        // 誤って除外されないことを確認する。
+        val cells = listOf(
+            cell("血圧(収縮期)", 0, 0, 150, 40),
+            cell("120", 200, 0, 240, 40),
+            cell("118", 320, 0, 360, 40)
+        )
+
+        val result = OcrParser.parseWithDate(cells)
+
+        assertEquals(listOf(OcrItem("血圧(収縮期)", "120", "")), result.items)
+        assertEquals(null, result.examDate)
+    }
+
     @Test
     fun `複数ページのセルはページごとに独立してクラスタリングされ結果は連結される`() {
         // 1枚目・2枚目は座標系が独立しているため、pageが異なれば座標が重なっていても


### PR DESCRIPTION
## 概要

Issue #13 の対応: OCR結果に、健診結果表のヘッダー行（検査日が並ぶ行）が項目データとして誤って抽出される不具合を修正する。

## 変更内容

- OcrParser.kt
  - buildGrid で復元したグリッドの各行について、行内で日付として解釈できるセルが2つ以上ある場合に「ヘッダー行」と判定し（isHeaderRow）、OcrItem への変換対象から除外する。
  - 日付判定（parseDateCell）は西暦4桁（2025/8/22、2025-08-22、2025.8.22）・西暦2桁（25/8/22）・和暦（R7.8.22 等、令和/平成/昭和/明治に対応）と、区切り文字違い（スラッシュ・ハイフン・ドット）を扱う。
  - 単一セルのみが日付に見えるだけではヘッダー行と判定しない（HEADER_ROW_MIN_DATE_CELLS = 2）。数値のみのデータ行を誤って落とさないための安全策。
  - ヘッダー行から、値として採用する列（暫定ルールの2列目 = VALUE_COLUMN_INDEX）に対応する検査日を抽出し、OcrParseResult(items, examDate) として返す新API parseWithDate を追加。
  - 既存の parse(cells): List OcrItem は parseWithDate(cells).items に委譲し、後方互換を維持（既存呼び出し元・既存テストへの影響なし）。
- OcrResultFragment.kt
  - OcrParser.parseWithDate を使用するよう変更し、取得できた検査日を保持。
  - 検査日入力ダイアログ（DatePickerDialog）の初期値に、取得できた検査日を反映する。取得できない場合は従来どおり今日の日付が初期値になり、ユーザーが手動で選択できる。
- OcrParserTest.kt
  - 西暦・和暦・区切り文字違いのヘッダー行判定と検査日抽出のテストを追加。
  - ヘッダー行が存在しない場合に examDate が null になることを確認するテストを追加。
  - 単一セルのみが偶然日付に見えるデータ行がヘッダー行と誤判定されず値として保持されることを確認するテストを追加。
  - 数値のみが並ぶデータ行がヘッダー行と誤判定されないことを確認するテストを追加。

## スコープについて

このIssueと同じ実行で Issue #14（複数列の「今回」列判定）も別セッションで OcrParser.kt に手を入れる予定のため、変更は「ヘッダー行判定・除外」に関する部分に最小限スコープしている。列から項目へのマッピング自体（暫定ルール: 1列目=項目名、2列目=値）には手を入れていない。

## 受け入れ基準

- [x] ヘッダー行（検査日が並ぶ行）が項目データとして抽出されない
- [x] 「2025/8/22」「22/7」のような日付・日付断片が項目名または値として確認画面に表示されない
- [x] ヘッダー行から検査日が取得でき、採用した列に対応する日付が確認画面の検査日の初期値に反映される
- [x] 検査日が取得できない画像でも、従来どおり手動入力で記録を保存できる
- [x] 西暦（2025/8/22）・和暦（R7.8.22）・区切り文字違い（2025-08-22）のパターンを含む単体テストが追加され、グリーンである
- [x] 数値のみのデータ行が誤ってヘッダー行と判定されないことがテストで確認されている

## テスト

- ./gradlew :app:testDebugUnitTest --tests 'com.rokusoudo.healthcheckup.OcrParserTest' → 16件全てグリーン（既存10件 + 新規6件）
- ./gradlew :app:testDebugUnitTest （全体）→ 全11テストスイート グリーン（failures=0, errors=0）

Closes #13
