### PR TITLE
feat(ocr): 複数列の健診表から「今回」列を自動判定し列選択UIを追加

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrColumnSelector.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrColumnSelector.kt
@@ -1,0 +1,268 @@
+package com.rokusoudo.healthcheckup
+
+import java.time.LocalDate
+
+/**
+ * [OcrParser.buildGrid] が復元したグリッドから、値として採用すべき列（「今回」列）を
+ * 特定するセレクタ（Issue #14）。
+ *
+ * ## 背景
+ * 日本の健診結果表は「項目名 / 今回 / 前回 / 前々回 / 基準値」のように複数列を持つ
+ * 経年比較型の表が事実上の標準である。[OcrParser] は現時点でグリッドの2列目を
+ * 無条件に値として採用する暫定ルールで動いており（Issue #12 のコメント参照）、
+ * どの列が「今回」かを判定していない。
+ *
+ * 本ファイルはその判定ロジックを [OcrParser] の既存関数に一切手を入れずに追加する
+ * （並行して進行中の Issue #13 とのマージ競合を避けるため、意図的に新規ファイルとして
+ * 分離している）。
+ *
+ * ## アルゴリズム
+ * 1. グリッド内で「日付として解釈できるセルが2つ以上ある行」を探し、見つかれば
+ *    その行を検査日ヘッダー行とみなす（[findHeaderRowIndex]）。複数見つかった場合は
+ *    最初の行を採用する
+ * 2. 項目名列（列0）を除く各列について、範囲表記（`3.5〜7.0` 等）や
+ *    「以下」「未満」「以上」「超」を含む列、またはヘッダー行のラベルに
+ *    「基準」「参考」を含む列は参考基準値列とみなし候補から除外する（[isReferenceRangeColumn]）
+ * 3. ヘッダー行が見つかり、残った候補列すべてについて重複のない日付が判明した場合は、
+ *    最も新しい日付の列を「今回」列として自動採用する
+ * 4. 日付で判別できない場合、候補列が1列だけならそれを採用する。2列以上残る、または
+ *    候補が0列の場合は自動判定失敗とし、呼び出し側にユーザー選択を促す
+ *
+ * ## Issue #13 との関係
+ * ヘッダー行・日付の判定ロジックは Issue #13（`isHeaderRow` / `parseDateCell` 相当）と
+ * 目的が重複するが、両Issueは並行実装のため本ファイルは意図的に自己完結させている。
+ * マージ時に日付パース処理の共通化を検討する余地がある（対応は代表判断）。
+ *
+ * ## スコープ外
+ * 前回・前々回の値を過去の記録として一括登録する機能は本Issueのスコープ外。
+ * 「今回」列1列を正しく取り込むところまでを対象とする。
+ */
+object OcrColumnSelector {
+
+    /** 項目名として扱う列インデックス（[OcrParser] の暫定ルールと同じ前提）。 */
+    private const val ITEM_NAME_COLUMN_INDEX = 0
+
+    /** 単一列（項目名+値1列）の健診表で採用する値列インデックス（従来の暫定ルールと同じ）。 */
+    private const val DEFAULT_VALUE_COLUMN_INDEX = 1
+
+    /** 列選択UIのプレビューに表示する最大項目数。 */
+    private const val PREVIEW_ITEM_COUNT = 3
+
+    /** ヘッダー行判定: 行内でこの数以上のセルが日付として解釈できる場合にヘッダー行とみなす。 */
+    private const val HEADER_ROW_MIN_DATE_CELLS = 2
+
+    // 範囲表記（例: "3.5〜7.0", "3.5-7.0"）。日付文字列（"2025-08-22"等）を誤って
+    // マッチさせないよう、行全体に完全一致する場合のみ範囲表記とみなす（アンカー必須）。
+    private val RANGE_PATTERN = Regex("""^[\d.]+\s*[~〜～\-–—]\s*[\d.]+$""")
+    private val RANGE_KEYWORDS = listOf("以下", "未満", "以上", "超")
+    private val REFERENCE_HEADER_KEYWORDS = listOf("基準", "参考")
+
+    // 西暦4桁（例: 2025/8/22, 2025-08-22, 2025.8.22）
+    private val SEIREKI_YEAR4_PATTERN = Regex("""^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})$""")
+
+    // 西暦2桁（例: 25/8/22）。健診結果表は近年の日付のため 2000年代とみなす。
+    private val SEIREKI_YEAR2_PATTERN = Regex("""^(\d{2})[-/.](\d{1,2})[-/.](\d{1,2})$""")
+
+    // 和暦（例: R7.8.22, H31.4.1）。元号の頭文字（R/H/S/M）+ 年 + 区切り + 月 + 区切り + 日。
+    private val WAREKI_PATTERN = Regex("""^([RHSMrhsm])(\d{1,2})[-/.](\d{1,2})[-/.](\d{1,2})$""")
+
+    /**
+     * グリッドから値として採用する列を判定する。
+     *
+     * @param grid [OcrParser.buildGrid] の出力
+     * @return 自動判定できれば [ColumnSelectionResult.Resolved]、判定できなければ
+     *         列候補付きの [ColumnSelectionResult.NeedsUserSelection]
+     */
+    fun selectValueColumn(grid: List<List<String>>): ColumnSelectionResult {
+        val columnCount = grid.maxOfOrNull { it.size } ?: 0
+        if (columnCount <= DEFAULT_VALUE_COLUMN_INDEX + 1) {
+            // 項目名列のみ、または値列が高々1つ（単一列の健診表）→ 列選択不要
+            return ColumnSelectionResult.Resolved(DEFAULT_VALUE_COLUMN_INDEX)
+        }
+
+        val headerRowIndex = findHeaderRowIndex(grid)
+        val valueColumns = (ITEM_NAME_COLUMN_INDEX + 1 until columnCount).toList()
+        val candidateColumns = valueColumns.filterNot { isReferenceRangeColumn(grid, it, headerRowIndex) }
+
+        if (candidateColumns.size == 1) {
+            return ColumnSelectionResult.Resolved(candidateColumns.first())
+        }
+        if (candidateColumns.isEmpty()) {
+            // 全列が基準値列と判定された場合は自動判定失敗として扱い、除外前の全列から選ばせる
+            return ColumnSelectionResult.NeedsUserSelection(buildCandidates(grid, valueColumns, headerRowIndex))
+        }
+
+        if (headerRowIndex != null) {
+            val columnDates = candidateColumns.associateWith { detectColumnDate(grid, headerRowIndex, it) }
+            val allDatesResolved = columnDates.values.all { it != null }
+            val distinctDates = columnDates.values.filterNotNull().distinct()
+            if (allDatesResolved && distinctDates.size == columnDates.size) {
+                val latestColumn = columnDates.entries.maxByOrNull { it.value!! }!!.key
+                return ColumnSelectionResult.Resolved(latestColumn)
+            }
+        }
+
+        return ColumnSelectionResult.NeedsUserSelection(buildCandidates(grid, candidateColumns, headerRowIndex))
+    }
+
+    /**
+     * グリッドを、指定した列インデックスを値列として [OcrItem] のリストに変換する。
+     * ユーザーが列選択ダイアログで列を選んだ後、その列の値で確認画面の項目リストを
+     * 再構築するために使用する。
+     *
+     * 行変換ルールは [OcrParser] の暫定ルール（列0=項目名、値列=指定インデックス。
+     * 単一セル1行の場合は正規表現ベースの後方互換フォールバック）と同一だが、値列の
+     * インデックスを固定値(1)ではなく引数で受け取れるようにした点のみが異なる。
+     * ヘッダー行の除外は行わない（本Issueのスコープ外。Issue #13 の担当範囲）。
+     */
+    fun rebuildItems(grid: List<List<String>>, valueColumnIndex: Int): List<OcrItem> {
+        val results = grid.mapNotNull { row -> rowToItem(row, valueColumnIndex) }
+        return results.ifEmpty { listOf(OcrItem("", "", "")) }
+    }
+
+    private fun rowToItem(row: List<String>, valueColumnIndex: Int): OcrItem? {
+        val nonBlank = row.filter { it.isNotBlank() }
+        if (nonBlank.isEmpty()) return null
+
+        if (nonBlank.size == 1) {
+            return parseLegacyLine(nonBlank.first())
+        }
+
+        val itemName = row.getOrNull(ITEM_NAME_COLUMN_INDEX)?.trim().orEmpty()
+        val value = row.getOrNull(valueColumnIndex)?.trim().orEmpty()
+        if (itemName.isBlank() && value.isBlank()) return null
+
+        return OcrItem(itemName = itemName, value = value, unit = "")
+    }
+
+    // 後方互換フォールバック用: 1セル内に「項目名(非空白) 数値 単位」が
+    // まとめて含まれる場合の従来パターン（[OcrParser] のフォールバックと同一）。
+    private val LEGACY_LINE_PATTERN = Regex("""(\S+)\s+([\d.]+)\s*([a-zA-Z/%]+)?""")
+
+    private fun parseLegacyLine(line: String): OcrItem? {
+        if (line.isBlank()) return null
+        val match = LEGACY_LINE_PATTERN.find(line) ?: return null
+        val (itemName, value, unit) = match.destructured
+        return OcrItem(itemName = itemName, value = value, unit = unit)
+    }
+
+    /**
+     * グリッド内で「日付として解釈できるセルが2つ以上ある行」を探し、見つかれば
+     * その行のインデックスを返す。複数見つかった場合は最初の行を採用する。
+     * タイトル行（例: "健康診断結果"）など日付を含まない行は無視される。
+     */
+    private fun findHeaderRowIndex(grid: List<List<String>>): Int? {
+        return grid.indexOfFirst { row -> row.count { parseDateCell(it) != null } >= HEADER_ROW_MIN_DATE_CELLS }
+            .takeIf { it >= 0 }
+    }
+
+    /**
+     * 指定した列が参考基準値列かどうかを判定する。ヘッダー行を除くデータ行の中に
+     * 範囲表記・キーワードを含むセルが1つでもあれば基準値列とみなす。
+     * ヘッダー行のラベル自体に「基準」「参考」を含む場合も基準値列とみなす。
+     */
+    private fun isReferenceRangeColumn(grid: List<List<String>>, columnIndex: Int, headerRowIndex: Int?): Boolean {
+        val headerLabel = headerRowIndex?.let { grid.getOrNull(it)?.getOrNull(columnIndex) }?.trim().orEmpty()
+        if (REFERENCE_HEADER_KEYWORDS.any { headerLabel.contains(it) }) return true
+
+        val dataCells = grid.filterIndexed { index, _ -> index != headerRowIndex }
+            .mapNotNull { it.getOrNull(columnIndex)?.trim() }
+            .filter { it.isNotBlank() }
+
+        return dataCells.any { cell -> RANGE_PATTERN.matches(cell) || RANGE_KEYWORDS.any { cell.contains(it) } }
+    }
+
+    /** ヘッダー行の指定列のセルを日付として解釈する。解釈できなければnull。 */
+    private fun detectColumnDate(grid: List<List<String>>, headerRowIndex: Int, columnIndex: Int): LocalDate? {
+        val text = grid.getOrNull(headerRowIndex)?.getOrNull(columnIndex) ?: return null
+        return parseDateCell(text)
+    }
+
+    /**
+     * 列選択UIに提示する候補リストを構築する。プレビューはヘッダー行を除くデータ行から
+     * 先頭 [PREVIEW_ITEM_COUNT] 件（空白セルを除く）を採用する。
+     */
+    private fun buildCandidates(
+        grid: List<List<String>>,
+        columnIndexes: List<Int>,
+        headerRowIndex: Int?
+    ): List<ColumnCandidate> {
+        val previewSourceRows = grid.filterIndexed { index, _ -> index != headerRowIndex }
+        return columnIndexes.map { col ->
+            val headerLabel = headerRowIndex?.let { grid.getOrNull(it)?.getOrNull(col) }?.trim().orEmpty()
+            val previews = previewSourceRows.mapNotNull { it.getOrNull(col)?.trim() }
+                .filter { it.isNotBlank() }
+                .take(PREVIEW_ITEM_COUNT)
+            ColumnCandidate(columnIndex = col, headerLabel = headerLabel, previewValues = previews)
+        }
+    }
+
+    /**
+     * セルのテキストを日付として解釈できる場合は [LocalDate] を返す。
+     * 西暦4桁・西暦2桁・和暦（令和/平成/昭和/明治）の区切り文字違い（"/", "-", "."）に対応する。
+     * 解釈できない、または存在しない日付（例: 2月30日）の場合はnullを返す。
+     */
+    private fun parseDateCell(text: String): LocalDate? {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return null
+
+        parseWareki(trimmed)?.let { return it }
+        parseSeirekiYear4(trimmed)?.let { return it }
+        parseSeirekiYear2(trimmed)?.let { return it }
+        return null
+    }
+
+    private fun parseWareki(text: String): LocalDate? {
+        val match = WAREKI_PATTERN.matchEntire(text) ?: return null
+        val (era, warekiYearStr, monthStr, dayStr) = match.destructured
+        val seirekiYear = toSeirekiYear(era.uppercase()[0], warekiYearStr.toInt()) ?: return null
+        return toLocalDateOrNull(seirekiYear, monthStr.toInt(), dayStr.toInt())
+    }
+
+    private fun parseSeirekiYear4(text: String): LocalDate? {
+        val match = SEIREKI_YEAR4_PATTERN.matchEntire(text) ?: return null
+        val (yearStr, monthStr, dayStr) = match.destructured
+        return toLocalDateOrNull(yearStr.toInt(), monthStr.toInt(), dayStr.toInt())
+    }
+
+    private fun parseSeirekiYear2(text: String): LocalDate? {
+        val match = SEIREKI_YEAR2_PATTERN.matchEntire(text) ?: return null
+        val (yearStr, monthStr, dayStr) = match.destructured
+        return toLocalDateOrNull(2000 + yearStr.toInt(), monthStr.toInt(), dayStr.toInt())
+    }
+
+    /** 和暦の元号1文字と和暦年から西暦年を求める。未知の元号の場合はnull。 */
+    private fun toSeirekiYear(era: Char, warekiYear: Int): Int? = when (era) {
+        'R' -> 2018 + warekiYear // 令和1年 = 2019年
+        'H' -> 1988 + warekiYear // 平成1年 = 1989年
+        'S' -> 1925 + warekiYear // 昭和1年 = 1926年
+        'M' -> 1867 + warekiYear // 明治1年 = 1868年
+        else -> null
+    }
+
+    /** 実在しない日付（2月30日など）の場合はnullを返す。 */
+    private fun toLocalDateOrNull(year: Int, month: Int, day: Int): LocalDate? =
+        runCatching { LocalDate.of(year, month, day) }.getOrNull()
+}
+
+/** [OcrColumnSelector.selectValueColumn] の結果を表す。 */
+sealed class ColumnSelectionResult {
+    /** 自動判定できた場合。[valueColumnIndex] をそのまま値列として使用する。 */
+    data class Resolved(val valueColumnIndex: Int) : ColumnSelectionResult()
+
+    /** 自動判定に失敗した場合。ユーザーに [candidates] から選ばせる。 */
+    data class NeedsUserSelection(val candidates: List<ColumnCandidate>) : ColumnSelectionResult()
+}
+
+/**
+ * 列選択UIに表示する列候補。
+ *
+ * @param columnIndex   グリッド内の列インデックス（[OcrColumnSelector.rebuildItems] にそのまま渡す）
+ * @param headerLabel   ヘッダー行のテキスト（取得できれば）。取得できなければ空文字列
+ * @param previewValues その列の先頭数項目分の値（空でないものを最大3件）
+ */
+data class ColumnCandidate(
+    val columnIndex: Int,
+    val headerLabel: String,
+    val previewValues: List<String>
+)

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrResultFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrResultFragment.kt
@@ -92,14 +92,61 @@ class OcrResultFragment : Fragment() {
         }
     }
 
-    private fun setupRecyclerView(cells: List<OcrCell>) {
-        val items = OcrParser.parse(cells).toMutableList()
-        ocrItemAdapter = OcrItemAdapter(items)
+    // Issue #14: 複数列の健診表（今回/前回/前々回）から「今回」列を特定するための
+    // グリッド。列選択ダイアログでユーザーが選んだ列から項目リストを再構築する際に使う。
+    private var ocrGrid: List<List<String>> = emptyList()
 
+    private fun setupRecyclerView(cells: List<OcrCell>) {
+        ocrGrid = OcrParser.buildGrid(cells)
+        when (val selection = OcrColumnSelector.selectValueColumn(ocrGrid)) {
+            is ColumnSelectionResult.Resolved -> {
+                bindItems(OcrColumnSelector.rebuildItems(ocrGrid, selection.valueColumnIndex))
+            }
+            is ColumnSelectionResult.NeedsUserSelection -> {
+                // 自動判定に失敗した場合は空のプレースホルダーを表示しつつ、
+                // 列選択ダイアログで選ばれた列の値でリストを再構築する。
+                bindItems(listOf(OcrItem("", "", "")))
+                showColumnSelectionDialog(selection.candidates)
+            }
+        }
+    }
+
+    private fun bindItems(items: List<OcrItem>) {
+        ocrItemAdapter = OcrItemAdapter(items.toMutableList())
         binding.recyclerOcrItems.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = ocrItemAdapter
         }
+    }
+
+    /**
+     * 複数列の健診表で「今回」列を自動判定できなかった場合に表示する列選択ダイアログ。
+     * 各候補列のヘッダーラベルとプレビュー値（先頭数項目）を提示し、ユーザーが選んだ列で
+     * 項目リストを再構築する（Issue #14 受け入れ基準）。
+     */
+    private fun showColumnSelectionDialog(candidates: List<ColumnCandidate>) {
+        val labels = candidates.mapIndexed { index, candidate ->
+            val headerPart = candidate.headerLabel.ifBlank {
+                getString(R.string.label_column_fallback, index + 1)
+            }
+            val previewPart = if (candidate.previewValues.isEmpty()) {
+                getString(R.string.label_column_no_preview)
+            } else {
+                candidate.previewValues.joinToString("、")
+            }
+            getString(R.string.label_column_item, headerPart, previewPart)
+        }.toTypedArray()
+
+        var selectedIndex = 0
+        android.app.AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.dialog_title_column_selection))
+            .setSingleChoiceItems(labels, selectedIndex) { _, which -> selectedIndex = which }
+            .setPositiveButton(getString(R.string.btn_select_column)) { _, _ ->
+                val chosenColumn = candidates[selectedIndex].columnIndex
+                bindItems(OcrColumnSelector.rebuildItems(ocrGrid, chosenColumn))
+            }
+            .setNegativeButton(getString(R.string.btn_cancel), null)
+            .show()
     }
 
     private fun setupSaveButton() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -32,6 +32,13 @@
     <string name="error_low_confidence">もう少し近づけて撮影してください</string>
     <string name="error_ocr_failed">OCR処理中にエラーが発生しました</string>
 
+    <!-- OCR result screen: 列選択 (Issue #14) -->
+    <string name="dialog_title_column_selection">取り込む列を選択してください（今回の列を自動判定できませんでした）</string>
+    <string name="btn_select_column">この列を選択</string>
+    <string name="label_column_fallback">列%1$d</string>
+    <string name="label_column_item">%1$s: %2$s</string>
+    <string name="label_column_no_preview">（プレビューなし）</string>
+
     <!-- S-02 Home hub (刷新001) -->
     <string name="title_home">ホーム</string>
     <string name="btn_home_register">登録</string>

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/OcrColumnSelectorTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/OcrColumnSelectorTest.kt
@@ -1,0 +1,225 @@
+package com.rokusoudo.healthcheckup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [OcrColumnSelector] のテスト（Issue #14）。
+ *
+ * 複数列の健診表（今回/前回/前々回 + 参考基準値）から「今回」列を特定するロジックを検証する。
+ * - 検査日ヘッダー行から最も新しい日付の列を選ぶケース（列の並び順に依存しないことを含む）
+ * - 参考基準値列を候補から除外するケース（範囲表記・キーワードの両方）
+ * - 自動判定に失敗し、ユーザー選択が必要と判定されるケース
+ * - 選択された列で項目リストを再構築する [OcrColumnSelector.rebuildItems]
+ */
+class OcrColumnSelectorTest {
+
+    // ------------------------------------------------------------
+    // 検査日による自動判定（列の並び順に依存しないこと）
+    // ------------------------------------------------------------
+
+    @Test
+    fun `最新回が最左列の場合その列が今回列として選ばれる`() {
+        val grid = listOf(
+            listOf("", "2025/8/22", "2024/8/20", "4.6-6.2"),
+            listOf("HbA1c", "5.6", "5.4", "4.6-6.2")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    @Test
+    fun `最新回が最右列の場合その列が今回列として選ばれる`() {
+        val grid = listOf(
+            listOf("", "2024/8/20", "2025/8/22", "4.6-6.2"),
+            listOf("HbA1c", "5.4", "5.6", "4.6-6.2")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertEquals(ColumnSelectionResult.Resolved(2), result)
+    }
+
+    @Test
+    fun `和暦の検査日でも最新列を判定できる`() {
+        // R7(2025)/8/22 のほうが R6(2024)/8/20 より新しい
+        val grid = listOf(
+            listOf("", "R7.8.22", "R6.8.20"),
+            listOf("HbA1c", "5.6", "5.4")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    @Test
+    fun `タイトル行があってもヘッダー行を正しく見つけて今回列を判定できる`() {
+        // 表の上に「健康診断結果」のようなタイトル行がある実際のスキャンを想定。
+        // ヘッダー行判定は行0固定ではなく、日付セルが2つ以上ある行を探して行う。
+        val grid = listOf(
+            listOf("健康診断結果", "", ""),
+            listOf("", "2025/8/22", "2024/8/20"),
+            listOf("HbA1c", "5.6", "5.4")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    // ------------------------------------------------------------
+    // 参考基準値列の除外
+    // ------------------------------------------------------------
+
+    @Test
+    fun `範囲表記の列は参考基準値列として除外される`() {
+        val grid = listOf(
+            listOf("", "2025/8/22", ""),
+            listOf("体重", "68.5", "60-80")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        // 基準値列(2)が除外され、候補が1列(1)のみになるため自動判定できる
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    @Test
+    fun `以下未満などのキーワードを含む列は参考基準値列として除外される`() {
+        val grid = listOf(
+            listOf("", "2025/8/22", "基準値"),
+            listOf("収縮期血圧", "120", "140以下")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    // ------------------------------------------------------------
+    // 自動判定に失敗するケース
+    // ------------------------------------------------------------
+
+    @Test
+    fun `検査日ヘッダーがなく候補列が複数残る場合はユーザー選択を要求する`() {
+        val grid = listOf(
+            listOf("HbA1c", "5.6", "5.4"),
+            listOf("体重", "68.5", "70.2")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertTrue(result is ColumnSelectionResult.NeedsUserSelection)
+        val candidates = (result as ColumnSelectionResult.NeedsUserSelection).candidates
+        assertEquals(listOf(1, 2), candidates.map { it.columnIndex })
+        assertEquals(listOf("5.6", "68.5"), candidates[0].previewValues)
+        assertEquals(listOf("5.4", "70.2"), candidates[1].previewValues)
+    }
+
+    @Test
+    fun `検査日が同一で判別できない場合はユーザー選択を要求する`() {
+        val grid = listOf(
+            listOf("", "2025/8/22", "2025/8/22"),
+            listOf("HbA1c", "5.6", "5.4")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertTrue(result is ColumnSelectionResult.NeedsUserSelection)
+    }
+
+    @Test
+    fun `ヘッダー行は特定できても一部の列だけ検査日が読み取れない場合はユーザー選択を要求する`() {
+        // ヘッダー行判定自体は成立する（列1・列3の2セルが日付として読める）が、
+        // 列2の日付が読み取れないため、日付での自動判定はできない
+        // （読めた列だけで最新を選ぶと誤った列を「今回」と判定しかねないため）。
+        val grid = listOf(
+            listOf("", "2025/8/22", "読み取れない日付", "2024/8/20"),
+            listOf("HbA1c", "5.6", "5.5", "5.4")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertTrue(result is ColumnSelectionResult.NeedsUserSelection)
+        val candidates = (result as ColumnSelectionResult.NeedsUserSelection).candidates
+        assertEquals(listOf(1, 2, 3), candidates.map { it.columnIndex })
+    }
+
+    // ------------------------------------------------------------
+    // 単一列の健診表（列選択不要）
+    // ------------------------------------------------------------
+
+    @Test
+    fun `単一の値列しかない場合は列選択なしでその列が採用される`() {
+        val grid = listOf(
+            listOf("身長", "172.5")
+        )
+
+        val result = OcrColumnSelector.selectValueColumn(grid)
+
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    @Test
+    fun `空のグリッドでも例外を投げずデフォルト列を返す`() {
+        val result = OcrColumnSelector.selectValueColumn(emptyList())
+
+        assertEquals(ColumnSelectionResult.Resolved(1), result)
+    }
+
+    // ------------------------------------------------------------
+    // rebuildItems: 選択された列で項目リストを再構築する
+    // ------------------------------------------------------------
+
+    @Test
+    fun `rebuildItemsは指定した列インデックスの値でOcrItemを再構築する`() {
+        val grid = listOf(
+            listOf("HbA1c", "5.6", "5.4"),
+            listOf("体重", "68.5", "70.2")
+        )
+
+        val result = OcrColumnSelector.rebuildItems(grid, valueColumnIndex = 2)
+
+        assertEquals(
+            listOf(
+                OcrItem("HbA1c", "5.4", ""),
+                OcrItem("体重", "70.2", "")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `rebuildItemsは単一セル1行の場合は従来の正規表現フォールバックを使う`() {
+        val grid = listOf(
+            listOf("血圧(収縮期) 120 mmHg"),
+            listOf("HbA1c", "5.6", "5.4")
+        )
+
+        val result = OcrColumnSelector.rebuildItems(grid, valueColumnIndex = 2)
+
+        assertEquals(
+            listOf(
+                OcrItem("血圧(収縮期)", "120", "mmHg"),
+                OcrItem("HbA1c", "5.4", "")
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `rebuildItemsは全行アンマッチの場合は空のOcrItem1件を返す`() {
+        val grid = listOf(
+            listOf("読み取り不能なテキストのみ")
+        )
+
+        val result = OcrColumnSelector.rebuildItems(grid, valueColumnIndex = 1)
+
+        assertEquals(1, result.size)
+        assertTrue(result[0].itemName.isBlank() && result[0].value.isBlank())
+    }
+}


### PR DESCRIPTION
## 概要

複数列（今回 / 前回 / 前々回 + 参考基準値）を持つ健診結果表から、OCR取り込み時に「今回」列を正しく採用するようにする。

`OcrParser` は現状、グリッドの2列目を無条件に「値」として採用しており、どの列が「今回」かを判定していなかった（Issue #12 のコメント参照）。日本の健診結果表はこの経年比較型の複数列表が事実上の標準であり、対応しないと実データで機能が使えない。

Closes #14

## 実装内容

- `OcrColumnSelector.kt`（新規ファイル）
  - グリッド内で「日付として解釈できるセルが2つ以上ある行」を検査日ヘッダー行として検出（タイトル行があっても行0固定にせず正しく見つける）
  - 範囲表記（`3.5〜7.0` 等）・キーワード（以下/未満/以上/超）・ヘッダーラベルの「基準」「参考」を含む列を参考基準値列として候補から除外
  - 残った候補列すべてに重複のない検査日が判明した場合のみ、最も新しい日付の列を「今回」列として自動採用（列の並び順に依存しない。一部列だけ日付が読めない場合や日付が同一の場合は安全側に倒してユーザー選択へ）
  - 候補列が1列のみに絞られた場合はその列を採用し、2列以上残る・日付で判別できない場合は `NeedsUserSelection` を返しユーザーに委ねる
  - `rebuildItems(grid, valueColumnIndex)`: 選択された列の値で `OcrItem` リストを再構築する（単一セル1行は従来どおり正規表現フォールバック）
- `OcrResultFragment.kt`
  - `OcrParser.buildGrid` → `OcrColumnSelector.selectValueColumn` の結果で分岐
  - 自動判定できた場合はそのまま項目リストを構築
  - 自動判定に失敗した場合は列選択ダイアログ（`AlertDialog` の単一選択リスト。各列のヘッダーラベル＋先頭3項目のプレビューを表示）を表示し、選択された列で項目リストを再構築
  - キャンセル時は空のプレースホルダー（従来の手動入力フォールバックと同じ挙動）のまま
- `strings.xml`: 列選択ダイアログ用の文言を追加

## 意図的にやらなかったこと（スコープ外）

- 前回・前々回の値を過去の記録として一括登録する機能（記録の重複判定・検査日の扱いを別途整理する必要があるため、Issue本文の記載どおりスコープ外）
- 画像アセットの生成（本Issueでは不要。列選択UIはテキストのみのAlertDialogで完結）

## Issue #13 との関係（マージ調整は代表が実施）

直前に別セッションでIssue #13（ヘッダー行の日付誤抽出、PR #35, `feature/issue-13-header-row-exclusion`）が実装されており、`OcrParser.kt` に `isHeaderRow` / `parseDateCell` / `parseWithDate` が追加されている。本PRはそのマージを待たず現在の `main` をベースに実装し、**`OcrParser.kt` には一切手を入れず**、列選択ロジックを新規ファイル `OcrColumnSelector.kt` として独立実装した。ヘッダー行・日付判定のロジックは目的が一部重複するが、両Issueは並行実装のため意図的に自己完結させている。マージ時に日付パース処理の共通化を検討する余地がある（対応は代表判断）。

## デザイン

`DESIGN.md` のとおり View/XML + Material Components ベースを維持。列選択ダイアログは既存コード（`showFacilityInputDialog` 等）と同じ `android.app.AlertDialog.Builder` を使用しており、アプリテーマ（`Theme.MaterialComponents.Light.NoActionBar` ＋ `colors.xml` のトークン）がそのまま適用されるため新規のカラー直書きはなし。

## テスト

`OcrColumnSelectorTest.kt`（新規, 14件）で以下を検証:

- 最新回が最左列・最右列いずれのケースでも正しく「今回」列を判定できること（受け入れ基準）
- 和暦の検査日でも判定できること
- タイトル行があってもヘッダー行を正しく見つけられること
- 参考基準値列が範囲表記・キーワードいずれのパターンでも除外されること（受け入れ基準）
- 検査日が読めない・複数列の判別がつかない場合（一部列だけ日付不明、日付が同一）は `NeedsUserSelection` になること（受け入れ基準）
- 単一列の健診表では列選択なしで従来どおり値が採用されること（受け入れ基準）
- `rebuildItems` が指定列の値で `OcrItem` を再構築すること（単一セル1行の後方互換フォールバック含む）

既存の `OcrParserTest.kt`（10件）は無変更のまま全件グリーン。

```
./gradlew :app:testDebugUnitTest
BUILD SUCCESSFUL
com.rokusoudo.healthcheckup.OcrColumnSelectorTest tests=14 failures=0 errors=0
com.rokusoudo.healthcheckup.OcrParserTest         tests=10 failures=0 errors=0
（他の既存テストスイートも含め合計71件、failures=0 errors=0）
```

## 受け入れ基準チェック

- [x] 複数列の健診表から、検査日が最も新しい列の値が採用される
- [x] 参考基準値列が値として採用されない
- [x] 自動判定に失敗した場合、確認画面で列を選択するUIが表示される
- [x] 列選択UIには各列のプレビューが表示され、ユーザーがどの列かを判断できる
- [x] 列を選択すると、その列の値で確認画面の項目リストが再構築される
- [x] 最新回が最左のケース・最右のケースの両方を含む単体テストが追加され、グリーンである
- [x] 単一列の健診表では列選択UIが表示されず、従来どおり値が取り込まれる
- [x] 列選択UIは `DESIGN.md` のトークン・ルールに準拠している
