### PR TITLE
feat(ocr): 項目マスタと照合しゴミ項目名を除外する

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/ItemMasterMatcher.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/ItemMasterMatcher.kt
@@ -1,0 +1,160 @@
+package com.rokusoudo.healthcheckup
+
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import java.text.Normalizer
+
+/**
+ * OCRで抽出した項目名を項目マスタ（[ItemMaster]）に正規化・照合するマッチャー（Issue #15）。
+ *
+ * ## 背景
+ * [OcrParser] は座標クラスタリングでグリッドを復元し「項目名・値・単位」を機械的に切り出すが、
+ * 項目マスタとの照合は行わない。そのため、OCRの誤認識や表の罫線・注記に由来する
+ * 「22/7」「87.0」のような意味をなさない文字列がそのまま項目名として確認画面に流れ込む。
+ * 本ファイルは、その最後の砦として項目マスタとの照合・正規化・除外を担う。
+ *
+ * [OcrParser] とは独立したファイル・独立した関数として実装する
+ * （Issue #14 列選択の並行実装（PR #36）と同一ファイルを競合させないため）。
+ *
+ * ## アルゴリズム
+ * 1. 項目名・マスタ項目名の双方を [normalize] で正規化する
+ *    （全角/半角、カッコ種別、スペース有無、大文字/小文字の表記ゆれを吸収）
+ * 2. 正規化後の完全一致を試みる
+ * 3. 完全一致しない場合は編集距離ベースの類似度（[similarity]）によるあいまい一致を試みる。
+ *    [FUZZY_SIMILARITY_THRESHOLD] 以上の類似度を持つマスタ項目のうち最も類似度が高いものを採用する
+ *    （例: 「γ-GTP」に対する「γ-GT」のような表記ゆれ・脱字を吸収する）
+ * 4. いずれにも該当しない行は除外する
+ * 5. 一致した行は、項目名をマスタの正式名称に、単位をマスタ登録値に置き換える
+ *    （OCRで読み取った単位が異なっていてもマスタの単位を優先する）
+ *
+ * 項目名・値の両方が空欄の行（[OcrParser] が抽出結果0件のときに返す手動入力用プレースホルダー等）は
+ * 照合・除外の対象外とし、そのまま保持する。
+ */
+object ItemMasterMatcher {
+
+    /**
+     * [match] の結果。
+     *
+     * @param items         マスタに正規化された項目のリスト（除外された行は含まない）
+     * @param excludedCount マスタに該当せず除外した行数
+     */
+    data class MatchResult(
+        val items: List<OcrItem>,
+        val excludedCount: Int
+    )
+
+    // あいまい一致の採用閾値。類似度がこの値を"超えた"マスタ項目のみ採用する。
+    // 「γ-GTP」(5文字) と「γ-GT」(4文字、1文字欠落) の類似度が 0.8 になるよう実測した上で、
+    // 無関係な短い文字列同士がたまたま高い類似度を持つケースを避けられる値として 0.75 を採用。
+    private const val FUZZY_SIMILARITY_THRESHOLD = 0.75
+
+    // カッコ種別の表記ゆれを吸収するため、正規化時に読み捨てる括弧文字。
+    // 全角丸カッコ・全角角カッコは NFKC 正規化で半角に変換されるため、変換後の半角文字と
+    // NFKC で変換されないCJK系の括弧（〔〕【】山括弧等）の両方を含める。
+    private val BRACKET_CHARS = "()[]{}〔〕【】<>＜＞".toSet()
+
+    /**
+     * OCR抽出結果を項目マスタに照合する。
+     *
+     * @param items   [OcrParser] が抽出した [OcrItem] のリスト
+     * @param masters 項目マスタの全件（[com.rokusoudo.healthcheckup.data.repository.HealthRepository.getAllMasters] 等で取得）
+     * @return マスタに正規化された項目のリストと除外件数
+     */
+    fun match(items: List<OcrItem>, masters: List<ItemMaster>): MatchResult {
+        val normalizedMasters = masters.map { it to normalize(it.itemName) }
+
+        val matched = mutableListOf<OcrItem>()
+        var excludedCount = 0
+
+        for (item in items) {
+            // 項目名・値の両方が空欄の行（手動入力用プレースホルダー等）は照合対象外
+            if (item.itemName.isBlank() && item.value.isBlank()) {
+                matched.add(item)
+                continue
+            }
+
+            val master = findBestMaster(normalize(item.itemName), normalizedMasters)
+            if (master != null) {
+                matched.add(item.copy(itemName = master.itemName, unit = master.unit))
+            } else {
+                excludedCount++
+            }
+        }
+
+        return MatchResult(items = matched, excludedCount = excludedCount)
+    }
+
+    private fun findBestMaster(
+        normalizedName: String,
+        normalizedMasters: List<Pair<ItemMaster, String>>
+    ): ItemMaster? {
+        if (normalizedName.isBlank()) return null
+
+        // 1. 正規化後の完全一致を優先する
+        normalizedMasters.firstOrNull { it.second == normalizedName }?.let { return it.first }
+
+        // 2. あいまい一致: 閾値を超える類似度の中で最も高いものを採用する
+        var bestMaster: ItemMaster? = null
+        var bestSimilarity = FUZZY_SIMILARITY_THRESHOLD
+        for ((master, normalizedMasterName) in normalizedMasters) {
+            val score = similarity(normalizedName, normalizedMasterName)
+            if (score > bestSimilarity) {
+                bestSimilarity = score
+                bestMaster = master
+            }
+        }
+        return bestMaster
+    }
+
+    /**
+     * 項目名の表記ゆれ（全角/半角、カッコ種別、スペース有無、大文字/小文字）を吸収した
+     * 比較用の正規化文字列を返す。
+     */
+    internal fun normalize(text: String): String {
+        val nfkc = Normalizer.normalize(text.trim(), Normalizer.Form.NFKC)
+        return buildString {
+            for (c in nfkc) {
+                if (c.isWhitespace()) continue
+                if (c in BRACKET_CHARS) continue
+                append(c.lowercaseChar())
+            }
+        }
+    }
+
+    /**
+     * 正規化済み文字列同士の類似度（0.0〜1.0）を、編集距離（レーベンシュタイン距離）から算出する。
+     * 1.0 が完全一致、0.0 が共通点なし。
+     */
+    internal fun similarity(a: String, b: String): Double {
+        if (a.isEmpty() && b.isEmpty()) return 1.0
+        val maxLen = maxOf(a.length, b.length)
+        if (maxLen == 0) return 1.0
+        val distance = levenshtein(a, b)
+        return 1.0 - distance.toDouble() / maxLen
+    }
+
+    /** 2文字列間のレーベンシュタイン距離（編集距離）を求める。 */
+    private fun levenshtein(a: String, b: String): Int {
+        if (a == b) return 0
+        if (a.isEmpty()) return b.length
+        if (b.isEmpty()) return a.length
+
+        var previousRow = IntArray(b.length + 1) { it }
+        var currentRow = IntArray(b.length + 1)
+
+        for (i in 1..a.length) {
+            currentRow[0] = i
+            for (j in 1..b.length) {
+                val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+                currentRow[j] = minOf(
+                    currentRow[j - 1] + 1,      // 挿入
+                    previousRow[j] + 1,         // 削除
+                    previousRow[j - 1] + cost   // 置換
+                )
+            }
+            val tmp = previousRow
+            previousRow = currentRow
+            currentRow = tmp
+        }
+        return previousRow[b.length]
+    }
+}

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrItemAdapter.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrItemAdapter.kt
@@ -75,4 +75,15 @@ class OcrItemAdapter(
 
     /** 編集済み内容を含む全アイテムを返す。TextWatcher により items は常に最新状態。 */
     fun getItems(): List<OcrItem> = items.toList()
+
+    /**
+     * 表示中の全アイテムを [newItems] で置き換える（Issue #15: 項目マスタ照合結果の反映）。
+     * 照合は非同期（DBアクセス）のため、初期表示後に確定したマスタ照合済みのリストへ
+     * 差し替えるために使用する。
+     */
+    fun submitItems(newItems: List<OcrItem>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
 }

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrResultFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/OcrResultFragment.kt
@@ -77,6 +77,7 @@ class OcrResultFragment : Fragment() {
         setupRecyclerView(cells)
         setupSaveButton()
         observeSaveState()
+        observeMasterMatchResult()
     }
 
     private fun setupErrorMessage(errorType: OcrAnalyzer.OcrError) {
@@ -105,6 +106,33 @@ class OcrResultFragment : Fragment() {
         binding.recyclerOcrItems.apply {
             layoutManager = LinearLayoutManager(requireContext())
             adapter = ocrItemAdapter
+        }
+
+        // Issue #15: 項目マスタとの照合（非同期）を開始する。結果は observeMasterMatchResult で反映する。
+        viewModel.matchItemsAgainstMaster(parseResult.items)
+    }
+
+    /**
+     * 項目マスタ照合結果（Issue #15）を反映する。
+     * 照合済みの項目名・単位でRecyclerViewを更新し、除外した行数を確認画面に表示する。
+     */
+    private fun observeMasterMatchResult() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.masterMatchResult.collect { result ->
+                    if (result == null) return@collect
+
+                    ocrItemAdapter.submitItems(result.items)
+
+                    if (result.excludedCount > 0) {
+                        binding.tvExcludedCount.text =
+                            getString(R.string.msg_items_excluded, result.excludedCount)
+                        binding.tvExcludedCount.visibility = View.VISIBLE
+                    } else {
+                        binding.tvExcludedCount.visibility = View.GONE
+                    }
+                }
+            }
         }
     }
 

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/ocrresult/OcrResultViewModel.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/ocrresult/OcrResultViewModel.kt
@@ -4,11 +4,13 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.rokusoudo.healthcheckup.ItemMasterMatcher
 import com.rokusoudo.healthcheckup.OcrItem
 import com.rokusoudo.healthcheckup.data.repository.HealthRepository
 import com.rokusoudo.healthcheckup.ui.notification.NotificationHelper
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /** 保存処理の状態 */
@@ -26,6 +28,22 @@ class OcrResultViewModel(
 
     private val _saveState = MutableStateFlow<SaveState>(SaveState.Idle)
     val saveState: StateFlow<SaveState> = _saveState
+
+    // Issue #15: OCR抽出結果を項目マスタに照合した結果。未実行の間はnull。
+    private val _masterMatchResult = MutableStateFlow<ItemMasterMatcher.MatchResult?>(null)
+    val masterMatchResult: StateFlow<ItemMasterMatcher.MatchResult?> = _masterMatchResult
+
+    /**
+     * OCR抽出結果を項目マスタ（[HealthRepository.getAllMasters]）に照合する（Issue #15）。
+     * 照合ロジック自体は [ItemMasterMatcher] に切り出しており、ここではマスタ取得と
+     * 結果の反映のみを担う。
+     */
+    fun matchItemsAgainstMaster(items: List<OcrItem>) {
+        viewModelScope.launch {
+            val masters = repository.getAllMasters().first()
+            _masterMatchResult.value = ItemMasterMatcher.match(items, masters)
+        }
+    }
 
     fun saveRecord(date: String, facility: String, items: List<OcrItem>) {
         viewModelScope.launch {

--- a/android/app/src/main/res/layout/fragment_ocr_result.xml
+++ b/android/app/src/main/res/layout/fragment_ocr_result.xml
@@ -34,6 +34,22 @@
         tools:text="読み取りに失敗しました。手動で入力してください"
         tools:visibility="visible" />
 
+    <!-- Excluded row count message (Issue #15: マスタに該当しない行を除外した件数を表示) -->
+    <TextView
+        android:id="@+id/tv_excluded_count"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="@color/text_secondary"
+        android:textSize="12sp"
+        android:paddingHorizontal="16dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/tv_error_message"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="マスタに該当しない3行を除外しました"
+        tools:visibility="visible" />
+
     <!-- RecyclerView for OCR items -->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_ocr_items"
@@ -41,7 +57,7 @@
         android:layout_height="0dp"
         android:clipToPadding="false"
         android:paddingBottom="16dp"
-        app:layout_constraintTop_toBottomOf="@id/tv_error_message"
+        app:layout_constraintTop_toBottomOf="@id/tv_excluded_count"
         app:layout_constraintBottom_toTopOf="@id/btn_add_item"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -27,6 +27,9 @@
     <string name="msg_save_success">保存しました</string>
     <string name="msg_save_error">保存に失敗しました: %s</string>
 
+    <!-- Issue #15: 項目マスタに該当しない行を除外した件数の表示 -->
+    <string name="msg_items_excluded">マスタに該当しない%d行を除外しました</string>
+
     <!-- OCR error messages (薬事法対応: 医療アドバイスなし) -->
     <string name="error_insufficient_text">読み取りに失敗しました。手動で入力してください</string>
     <string name="error_low_confidence">もう少し近づけて撮影してください</string>

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/ItemMasterMatcherTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/ItemMasterMatcherTest.kt
@@ -1,0 +1,188 @@
+package com.rokusoudo.healthcheckup
+
+import com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase
+import com.rokusoudo.healthcheckup.data.db.entity.ItemCategories
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * ItemMasterMatcher のテスト（Issue #15）。
+ *
+ * OCRで抽出した項目名を項目マスタに正規化・照合し、該当しない行を除外するロジックを検証する。
+ * - 全角/半角・カッコ種別・スペース有無の表記ゆれ吸収
+ * - 編集距離ベースのあいまい一致（γ-GTP/γ-GT のような別名・脱字）
+ * - あいまい一致の閾値を満たさない行（OCR誤認識由来のゴミ）の除外
+ * - 単位のマスタ値への統一
+ * - マスタに存在する項目が誤って除外されないこと（回帰）
+ */
+class ItemMasterMatcherTest {
+
+    private val masters = listOf(
+        ItemMaster("身長", "cm", null, null, ItemCategories.BODY),
+        ItemMaster("体重", "kg", null, null, ItemCategories.BODY),
+        ItemMaster("BMI", "kg/m2", 18.5, 25.0, ItemCategories.BODY),
+        ItemMaster("AST(GOT)", "U/L", null, 30.0, ItemCategories.LIVER),
+        ItemMaster("γ-GTP", "U/L", null, 50.0, ItemCategories.LIVER),
+        ItemMaster("HbA1c", "%", null, 5.5, ItemCategories.GLUCOSE)
+    )
+
+    private fun item(name: String, value: String, unit: String = "") = OcrItem(name, value, unit)
+
+    // ------------------------------------------------------------
+    // 完全一致・表記ゆれ吸収
+    // ------------------------------------------------------------
+
+    @Test
+    fun `完全一致する項目名はそのまま採用される`() {
+        val result = ItemMasterMatcher.match(listOf(item("身長", "172.5", "cm")), masters)
+        assertEquals(0, result.excludedCount)
+        assertEquals(listOf(OcrItem("身長", "172.5", "cm")), result.items)
+    }
+
+    @Test
+    fun `全角英数字とスペースの表記ゆれが吸収されてマスタ名に正規化される`() {
+        // OCR誤認識により全角化・スペース混入した「ＡＳＴ （ ＧＯＴ ）」を想定
+        val result = ItemMasterMatcher.match(listOf(item("ＡＳＴ （ ＧＯＴ ）", "25", "U/L")), masters)
+        assertEquals(0, result.excludedCount)
+        assertEquals("AST(GOT)", result.items.single().itemName)
+    }
+
+    @Test
+    fun `カッコ種別の違いが吸収されてマスタ名に正規化される`() {
+        val bracketVariants = listOf("AST[GOT]", "AST【GOT】", "AST〔GOT〕", "AST（GOT）")
+        for (variant in bracketVariants) {
+            val result = ItemMasterMatcher.match(listOf(item(variant, "25", "U/L")), masters)
+            assertEquals("variant=$variant", 0, result.excludedCount)
+            assertEquals("variant=$variant", "AST(GOT)", result.items.single().itemName)
+        }
+    }
+
+    @Test
+    fun `OCR側の単位表記に関わらずマスタの単位が採用される`() {
+        val result = ItemMasterMatcher.match(listOf(item("体重", "68.5", "ｋｇ")), masters)
+        assertEquals(0, result.excludedCount)
+        // 単位はマスタ値優先のため OCR 側の全角単位はそのまま使われない
+        assertEquals("kg", result.items.single().unit)
+    }
+
+    // ------------------------------------------------------------
+    // あいまい一致（編集距離）
+    // ------------------------------------------------------------
+
+    @Test
+    fun `1文字脱落したγ-GTPの別名がγ-GTPに正規化される`() {
+        val result = ItemMasterMatcher.match(listOf(item("γ-GT", "45", "U/L")), masters)
+        assertEquals(0, result.excludedCount)
+        assertEquals("γ-GTP", result.items.single().itemName)
+    }
+
+    @Test
+    fun `OCR誤認識による1文字違いはあいまい一致でマスタ名に正規化される`() {
+        val result = ItemMasterMatcher.match(listOf(item("HbAlc", "5.6", "%")), masters)
+        assertEquals(0, result.excludedCount)
+        assertEquals("HbA1c", result.items.single().itemName)
+    }
+
+    // ------------------------------------------------------------
+    // 閾値未満（ゴミ行）の除外
+    // ------------------------------------------------------------
+
+    @Test
+    fun `罫線由来の意味をなさない項目名22-7は除外される`() {
+        val result = ItemMasterMatcher.match(listOf(item("22/7", "23", "/")), masters)
+        assertEquals(1, result.excludedCount)
+        assertTrue(result.items.isEmpty())
+    }
+
+    @Test
+    fun `注記由来の意味をなさない項目名87-0は除外される`() {
+        val result = ItemMasterMatcher.match(listOf(item("87.0", "1", "")), masters)
+        assertEquals(1, result.excludedCount)
+        assertTrue(result.items.isEmpty())
+    }
+
+    @Test
+    fun `該当行と除外行が混在する場合は該当行のみ採用され件数が正しくカウントされる`() {
+        val result = ItemMasterMatcher.match(
+            listOf(
+                item("身長", "172.5", "cm"),
+                item("22/7", "23", "/"),
+                item("体重", "68.5", "kg"),
+                item("87.0", "1", "")
+            ),
+            masters
+        )
+        assertEquals(2, result.excludedCount)
+        assertEquals(
+            listOf(OcrItem("身長", "172.5", "cm"), OcrItem("体重", "68.5", "kg")),
+            result.items
+        )
+    }
+
+    // ------------------------------------------------------------
+    // 単位のマスタ値への統一
+    // ------------------------------------------------------------
+
+    @Test
+    fun `OCRで読み取った単位がマスタと異なる場合マスタの単位が採用される`() {
+        val result = ItemMasterMatcher.match(listOf(item("BMI", "22.0", "kg/m^2")), masters)
+        assertEquals("kg/m2", result.items.single().unit)
+    }
+
+    // ------------------------------------------------------------
+    // 空行（手動入力用プレースホルダー）は照合対象外
+    // ------------------------------------------------------------
+
+    @Test
+    fun `項目名も値も空欄の行は照合対象外としてそのまま保持される`() {
+        val result = ItemMasterMatcher.match(listOf(item("", "", "")), masters)
+        assertEquals(0, result.excludedCount)
+        assertEquals(listOf(OcrItem("", "", "")), result.items)
+    }
+
+    // ------------------------------------------------------------
+    // マスタが空の場合
+    // ------------------------------------------------------------
+
+    @Test
+    fun `マスタが空の場合は実データ行が全て除外される`() {
+        val result = ItemMasterMatcher.match(listOf(item("身長", "172.5", "cm")), emptyList())
+        assertEquals(1, result.excludedCount)
+        assertTrue(result.items.isEmpty())
+    }
+
+    // ------------------------------------------------------------
+    // 回帰: マスタに存在する項目が誤って除外されないこと
+    // ------------------------------------------------------------
+
+    @Test
+    fun `デフォルト項目マスタの全項目は自分自身に完全一致し誤って除外されない`() {
+        val defaultMasters = HealthCheckupDatabase.DEFAULT_ITEM_MASTERS
+        for (master in defaultMasters) {
+            val result = ItemMasterMatcher.match(
+                listOf(item(master.itemName, "1", master.unit)),
+                defaultMasters
+            )
+            assertEquals("item=${master.itemName}", 0, result.excludedCount)
+            assertEquals("item=${master.itemName}", master.itemName, result.items.single().itemName)
+        }
+    }
+
+    // ------------------------------------------------------------
+    // 正規化・類似度の単体テスト
+    // ------------------------------------------------------------
+
+    @Test
+    fun `normalizeは全角半角・カッコ・スペース・大文字小文字の差異を吸収する`() {
+        assertEquals(ItemMasterMatcher.normalize("AST(GOT)"), ItemMasterMatcher.normalize("ａｓｔ （ｇｏｔ）"))
+        assertEquals(ItemMasterMatcher.normalize("AST(GOT)"), ItemMasterMatcher.normalize("AST[GOT]"))
+    }
+
+    @Test
+    fun `similarityは完全一致で1-0を返し無関係な文字列では低い値を返す`() {
+        assertEquals(1.0, ItemMasterMatcher.similarity("abc", "abc"), 0.0001)
+        assertTrue(ItemMasterMatcher.similarity("22/7", "身長") < 0.5)
+    }
+}


### PR DESCRIPTION
## 概要

OCR結果確認画面に、罫線・注記由来の意味をなさない項目名（例:「22/7」「87.0」）がそのまま表示されてしまう問題を修正する。抽出した項目名を項目マスタ（`ItemMaster`）に正規化・照合し、該当しない行を除外する。

Closes #15

## 並行実装に関する注記（重要）

Issue #14（列選択）の実装が PR #36 (`feature/issue-14-column-selection`) として `OcrParser.kt` に手を入れていますが、本 PR 作成時点で未マージです。指示に基づき **PR #36 のマージを待たず、現在の main をベースに実装**しました。

`OcrParser.kt` には一切手を加えず、項目マスタとの照合・正規化ロジックは新規ファイル `ItemMasterMatcher.kt` に完全に独立させています。これにより PR #36 とのファイル競合を避けています（`OcrResultFragment.kt` / `OcrItemAdapter.kt` / `OcrResultViewModel.kt` には軽微な追加変更があります。PR #36 が先にマージされた場合、コンフリクトが出ても軽微なはずです）。

## 実装内容

- **`ItemMasterMatcher.kt`（新規）**: OCR抽出結果の項目名を項目マスタに照合する独立したオブジェクト
  - 正規化（NFKC変換による全角/半角吸収、カッコ種別の吸収、スペース除去、大文字/小文字統一）
  - 正規化後の完全一致を優先し、一致しない場合は編集距離（レーベンシュタイン距離）ベースの類似度によるあいまい一致を試みる（閾値 0.75。「γ-GTP」に対する「γ-GT」のような別名・脱字を吸収）
  - 閾値を満たす一致がない行は除外し、除外件数を返す
  - 一致した行は項目名をマスタの正式名称に、単位をマスタ登録値に置き換える（OCRで読み取った単位よりマスタを優先）
  - 項目名・値がともに空欄の行（OCR抽出結果が0件のときの手動入力用プレースホルダー）は照合対象外として素通しする
- **`OcrResultViewModel.kt`**: `matchItemsAgainstMaster()` を追加し、`HealthRepository.getAllMasters()` からマスタ一覧を取得して `ItemMasterMatcher` に照合させ、結果を `StateFlow` で公開
- **`OcrResultFragment.kt`**: OCR解析直後に非同期でマスタ照合を実行し、結果が届き次第 RecyclerView を更新。除外件数がある場合は「マスタに該当しない%d行を除外しました」を表示
- **`OcrItemAdapter.kt`**: `submitItems()` を追加し、非同期で確定したマスタ照合済みリストへの差し替えに対応
- **レイアウト/文言**: `fragment_ocr_result.xml` に除外件数表示用の `TextView` を追加。DESIGN.md のトークンに従い `@color/text_secondary` / 12sp を使用（色・サイズの直書きなし）。文言は `strings.xml` に `msg_items_excluded` として追加

## 受け入れ基準チェック

- [x] 抽出した項目名が項目マスタの項目名に正規化される
- [x] 全角・半角、カッコ種別、スペース有無の表記ゆれが吸収される
- [x] あいまい一致の閾値を満たさない行が確認画面に表示されない
- [x] 「22/7」「87.0」のような項目名が確認画面に表示されない
- [x] 除外した行がある場合、その件数が確認画面に表示される
- [x] 除外件数の表示は DESIGN.md のトークン・ルールに準拠している
- [x] 単位がマスタ登録値に統一される
- [x] 表記ゆれ・あいまい一致・除外ケースを含む単体テストが追加され、グリーンである
- [x] マスタに存在する項目が誤って除外されないことがテストで確認されている（デフォルト項目マスタ全項目の回帰テストを追加）

## テスト結果

- `ItemMasterMatcherTest`: 15件全てパス
- `./gradlew :app:testDebugUnitTest`（全ユニットテスト）: 全てグリーン（既存の `OcrParserTest` 16件含め、既存テストの破壊なし）

## 制約事項

- 実装過程で画像アセットの生成は行っていません
