### PR TITLE
fix(android): アプリ起動時にFirestoreと再同期する (#26)

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/MainActivity.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/MainActivity.kt
@@ -5,12 +5,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.google.firebase.auth.FirebaseAuth
 import com.rokusoudo.healthcheckup.databinding.ActivityMainBinding
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
@@ -49,6 +51,20 @@ class MainActivity : AppCompatActivity() {
             setOf(R.id.homeFragment, R.id.loginFragment)
         )
         binding.toolbar.setupWithNavController(navController, appBarConfiguration)
+
+        resyncWithFirestoreOnStartup()
+    }
+
+    /**
+     * Issue #26: ログイン済み状態でアプリを起動した際、Firestoreとの再同期をバックグラウンドで行う。
+     * 未ログインの場合や、多重実行の抑止は HealthRepository.resyncOnStartupIfNeeded() 側で判定する。
+     * UIをブロックしないよう lifecycleScope から呼び出す。
+     */
+    private fun resyncWithFirestoreOnStartup() {
+        val app = application as HealthCheckupApp
+        lifecycleScope.launch {
+            app.repository.resyncOnStartupIfNeeded()
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
@@ -8,6 +8,7 @@ import com.rokusoudo.healthcheckup.data.db.dao.ItemTrend
 import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
 import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
 import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -23,6 +24,9 @@ class HealthRepository(
     private val firestoreRepository: HealthCloudSync,
     private val currentUidProvider: () -> String? = { FirebaseAuth.getInstance().currentUser?.uid }
 ) {
+
+    /** Issue #26: アプリ起動時の再同期が既に実行された（または実行中）かどうか。1起動＝1インスタンス分に限り一度だけ true になる。 */
+    private val startupResyncAttempted = AtomicBoolean(false)
 
     /**
      * OCR結果・手動入力を診断記録として保存する。
@@ -169,6 +173,29 @@ class HealthRepository(
         } catch (_: Exception) {
             // ネットワーク不可時は無視（既存のローカルデータをそのまま使用）
         }
+    }
+
+    /**
+     * Issue #26: ログイン済み状態でアプリを起動したとき、Firestoreとの再同期を行う。
+     *
+     * `LoginViewModel.signIn()` はサインイン直後の初回復元のみをカバーしており、
+     * 既にログイン済みのユーザーがアプリを再起動した場合は `restoreFromFirestore` が
+     * 一度も呼ばれず、Web側で追加・編集した記録がAndroidに反映されなかった（US-S01未達）。
+     *
+     * - 未ログイン（uidが取れない）場合は何もしない。
+     * - 1つの HealthRepository インスタンス（＝アプリプロセスの1起動）につき、
+     *   実際の同期処理は最初の1回のみ実行する（`startupResyncAttempted` による多重実行防止）。
+     *   同じインスタンスに対して複数回呼び出しても2回目以降は即座に返る（冪等）。
+     * - Firestore例外・オフライン時のフォールバックは `restoreFromFirestore` に委譲する
+     *   （既存のローカルデータを保持し、クラッシュしない）。
+     *
+     * 呼び出し元（例: MainActivity.onCreate）は UI をブロックしないよう
+     * `lifecycleScope.launch` 等のバックグラウンドコルーチンから呼び出すこと。
+     */
+    suspend fun resyncOnStartupIfNeeded() {
+        if (!startupResyncAttempted.compareAndSet(false, true)) return
+        val uid = currentUidProvider() ?: return
+        restoreFromFirestore(uid)
     }
 
     companion object {

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryStartupResyncTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryStartupResyncTest.kt
@@ -1,0 +1,143 @@
+package com.rokusoudo.healthcheckup.data.repository
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #26: アプリ起動時の Firestore 再同期（resyncOnStartupIfNeeded）を検証する。
+ *
+ * - ログイン済み（uidが取れる）場合のみ再同期が実行されること
+ * - 未ログインの場合は何も起こらないこと
+ * - 同一インスタンスへの複数回呼び出しでも、実際の同期は1回しか行われないこと（多重実行防止）
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class HealthRepositoryStartupResyncTest {
+
+    private lateinit var db: HealthCheckupDatabase
+    private lateinit var cloudSync: FakeHealthCloudSync
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            HealthCheckupDatabase::class.java
+        ).allowMainThreadQueries().build()
+        cloudSync = FakeHealthCloudSync()
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    @Test
+    fun `ログイン済みならアプリ起動時にFirestoreから再同期される`() = runBlocking {
+        cloudSync.recordsToReturn = listOf(
+            ExaminationRecord(id = 1L, date = "2026-08-01", facility = "Web入力", createdAt = 1000L) to
+                listOf(
+                    ExaminationItem(
+                        recordId = 1L,
+                        itemName = "LDL",
+                        value = "150",
+                        unit = "mg/dL",
+                        referenceMin = null,
+                        referenceMax = 139.0,
+                        isAbnormal = true
+                    )
+                )
+        )
+        cloudSync.mastersToReturn = listOf(ItemMaster("LDL", "mg/dL", null, 139.0))
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+
+        repository.resyncOnStartupIfNeeded()
+
+        assertEquals(1, cloudSync.fetchRecordsCallCount)
+        assertEquals(1, cloudSync.fetchItemMastersCallCount)
+        val records = db.recordDao().getById(1L)
+        assertTrue(records != null)
+        val items = db.itemDao().getByRecordIdOnce(1L)
+        assertEquals(1, items.size)
+        assertEquals("LDL", items[0].itemName)
+    }
+
+    @Test
+    fun `未ログインならFirestoreとの再同期は実行されない`() = runBlocking {
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { null })
+
+        repository.resyncOnStartupIfNeeded()
+
+        assertEquals(0, cloudSync.fetchRecordsCallCount)
+        assertEquals(0, cloudSync.fetchItemMastersCallCount)
+    }
+
+    @Test
+    fun `同一インスタンスに複数回呼び出しても再同期は1回しか実行されない`() = runBlocking {
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+
+        repository.resyncOnStartupIfNeeded()
+        repository.resyncOnStartupIfNeeded()
+        repository.resyncOnStartupIfNeeded()
+
+        assertEquals(1, cloudSync.fetchRecordsCallCount)
+        assertEquals(1, cloudSync.fetchItemMastersCallCount)
+    }
+
+    @Test
+    fun `Firestore例外時はクラッシュせずローカルデータが保持される`() = runBlocking {
+        val localRecordId = db.recordDao().insert(
+            ExaminationRecord(date = "2026-07-01", facility = "既存ローカル", createdAt = 500L)
+        )
+        cloudSync.shouldThrow = true
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+
+        // 例外が外に伝播しないこと
+        repository.resyncOnStartupIfNeeded()
+
+        val localRecord = db.recordDao().getById(localRecordId)
+        assertTrue(localRecord != null)
+        assertEquals("既存ローカル", localRecord!!.facility)
+    }
+
+    private class FakeHealthCloudSync : HealthCloudSync {
+        var recordsToReturn: List<Pair<ExaminationRecord, List<ExaminationItem>>> = emptyList()
+        var mastersToReturn: List<ItemMaster> = emptyList()
+        var shouldThrow: Boolean = false
+        var fetchRecordsCallCount: Int = 0
+        var fetchItemMastersCallCount: Int = 0
+
+        override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
+            // 本テストでは未使用
+        }
+
+        override suspend fun saveItemMaster(uid: String, master: ItemMaster) {
+            // 本テストでは未使用
+        }
+
+        override suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> {
+            fetchRecordsCallCount++
+            if (shouldThrow) throw RuntimeException("Firestore unavailable")
+            return recordsToReturn
+        }
+
+        override suspend fun fetchItemMasters(uid: String): List<ItemMaster> {
+            fetchItemMastersCallCount++
+            if (shouldThrow) throw RuntimeException("Firestore unavailable")
+            return mastersToReturn
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,16 @@
 
 - **Cloud Firestore** を単一の真実の源（Single Source of Truth）とする
 - **Android**: Room をオフラインキャッシュとして保持し、Firestore と双方向同期
+  - push（Room→Firestore）: 記録保存時（`saveRecord`）・項目マスター更新時（`upsertMaster`）に都度実行
+  - pull（Firestore→Room）: 次の2箇所から `HealthRepository.restoreFromFirestore(uid)` を呼び出す
+    - サインイン成功直後（`LoginViewModel.signIn()`）: 初回ログイン時、他端末のデータを取り込む
+    - アプリ起動時（`MainActivity.onCreate()` → `HealthRepository.resyncOnStartupIfNeeded()`、Issue #26）:
+      既にログイン済みのユーザーがアプリを再起動した場合、Web側で追加・編集された記録を反映する。
+      `lifecycleScope` 上のバックグラウンドコルーチンから呼び出し、UIをブロックしない。
+      未ログイン時は何もせず、`HealthRepository` インスタンスあたり（＝1起動あたり）実際の同期は1回のみに制限する（多重実行防止）。
+      Firestore例外・オフライン時は無視し、既存のローカルデータをそのまま使用する。
+      なお `restoreFromFirestore` は upsert のみで、Firestore側に存在しない記録をRoomから削除しない
+      （Web側で削除した記録の反映は本Issueのスコープ外・別Issueで対応）。
 - **Web**: Firestore を直接参照（ローカルキャッシュ不要、MVP段階）
 - **認証**: 両プラットフォームとも Firebase Auth（同一プロジェクト）でユーザーIDを共有
 - **データ分離**: Firestoreのパス `users/{uid}/records/{recordId}` でユーザーごとに分離
@@ -79,7 +89,7 @@ flowchart TB
     U2 --> HOST --> WUI
     UI -->|認証| AUTH
     WUI -->|認証| AUTH
-    REPO -->|同期（保存時 push / 初回ログイン時 pull）| FS
+    REPO -->|同期（保存時 push / ログイン時・アプリ起動時 pull）| FS
     WUI <--> FS
     UI -->|ACTION_SENDTO| MAIL
 ```


### PR DESCRIPTION
## 概要

Closes #26

ログイン済み状態のユーザーがアプリを起動しても Firestore との再同期（`restoreFromFirestore`）が一度も呼ばれず、Web で追加・編集した診断記録・項目マスターが Android 側に反映されない問題を修正しました。

## 変更内容

- `HealthRepository.resyncOnStartupIfNeeded()` を追加
  - 未ログイン（uidが取得できない）場合は何もしない
  - `HealthRepository` インスタンス（＝アプリの1起動）あたり、実際の同期処理は最初の1回のみ実行（`AtomicBoolean` による多重実行防止・冪等）
  - Firestore例外・オフライン時のフォールバックは既存の `restoreFromFirestore` に委譲（クラッシュせずローカルデータを保持）
- `MainActivity.onCreate()` から `lifecycleScope` 経由でバックグラウンド呼び出し（UIをブロックしない）
  - `LoginViewModel.signIn()` 内の既存の初回復元呼び出しはそのまま維持（別経路として共存）
- `HealthCloudSync` のフェイクを使った単体テストを追加（`HealthRepositoryStartupResyncTest.kt`）
  - ログイン済みなら再同期される
  - 未ログインなら再同期されない
  - 同一インスタンスへの複数回呼び出しでも実際の同期は1回のみ
  - Firestore例外時にクラッシュせずローカルデータが保持される
- `docs/architecture.md` の同期タイミングの記述（データ同期方針・環境構成図）を実装に合わせて更新

## スコープ外（Issue本文に記載の通り）

- Web側で削除した記録の Android への反映（`restoreFromFirestore` は upsert のみで削除はしない）
- `onResume` ごとの再同期

## テスト

- `./gradlew :app:compileDebugKotlin` 成功
- `./gradlew :app:testDebugUnitTest` 成功（既存テスト含め全件パス）

## 受け入れ基準チェック

- [x] ログイン済み状態でアプリを起動すると、Firestore上の最新の記録・項目マスターがRoomに反映される
- [x] 未ログイン状態では再同期を実行しない
- [x] ネットワーク不可・Firestore例外時にクラッシュせず、既存のローカルデータが保持される
- [x] 画面遷移を繰り返しても再同期が多重実行されない（HealthRepositoryインスタンス単位で冪等）
- [x] フェイクのHealthCloudSyncを使った単体テストを追加
- [x] docs/architecture.mdの同期タイミングの記述を更新
