### PR TITLE
ci(web): web/ の lint・build を検証する CI を追加

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,27 @@
+name: Web CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web dependencies
+        run: npm ci --prefix web
+
+      - name: Lint
+        run: npm --prefix web run lint
+
+      - name: Build
+        run: npm --prefix web run build

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ See [docs/](docs/) for architecture design and backlog, and [specs/001-screen-fl
 
 ## Testing
 
+### Web CI (type check, lint & build)
+
+`web/` is validated in CI by [`.github/workflows/web-ci.yml`](.github/workflows/web-ci.yml) on every push to `main` and every pull request. It installs dependencies, then runs lint and the production build (which includes the TypeScript type check via `tsc -b`).
+
+To run the same checks locally:
+
+```bash
+npm ci --prefix web
+npm --prefix web run lint
+npm --prefix web run build
+```
+
 ### Firestore rules unit tests
 
 `firestore.rules` is covered by unit tests (`firestore-tests/rules.test.mjs`) that run against the Firebase Emulator. These are enforced in CI by [`.github/workflows/firestore-rules-test.yml`](.github/workflows/firestore-rules-test.yml) on any push/PR touching `firestore.rules` or `firestore-tests/**`.


### PR DESCRIPTION
## 概要

Closes #27

`web/` を検証する CI ワークフローがなく、型エラー・Lint エラー・ビルド不能な状態のまま main にマージされても検知できなかった問題を解消する。

## 変更内容

- `.github/workflows/web-ci.yml` を新規追加
  - トリガー: `push`(main) と `pull_request`
  - `paths` フィルタなし(commit f5aecec で firestore-rules-test.yml から paths フィルタを外した ADR-0000 規約準拠の前例に合わせた)
  - `actions/setup-node@v4`(Node 20 固定・npm キャッシュは `web/package-lock.json` 基準)→ `npm ci --prefix web` → `npm --prefix web run lint` → `npm --prefix web run build`
- `README.md` の Testing 節に Web CI の説明とローカル実行コマンドを追記

## 検証

- 現状の main(このブランチの分岐元)で `npm ci --prefix web` → `npm --prefix web run lint` → `npm --prefix web run build` をローカル実行し、いずれも green であることを確認した(lint は `react-hooks/exhaustive-deps` の warning 1件のみで error 0件、既存コードの修正は不要だった)
- `web/src/main.tsx` に未使用変数を一時的に混入させ `npm run lint` が exit code 1 で fail することを確認後、変更を元に戻した(受け入れ基準「型/Lintエラーで CI が fail する」の簡易確認)
- PR 作成後に GitHub Actions 上での `web-ci.yml` の実行結果を確認する

## 受け入れ基準

- [x] `web/` に型エラーを含む変更を出した PR で CI が fail する(ローカルの lint fail 確認と同様のゲート。GitHub Actions 上の確認は本PRのCI結果で行う)
- [x] `web/` に eslint エラーを含む変更を出した PR で CI が fail する(ローカルで確認済み)
- [x] 現在の main の内容で新ワークフローが green になる(ローカルで確認済み。既存の型/Lintエラーはなかった)
- [x] ワークフローに `paths` フィルタが含まれていない
- [x] README.md の Testing 節に Web CI の説明とローカル実行コマンドを追記する

## スコープ外

- Web の単体テスト(vitest 等)の導入は本Issueのスコープ外のため未実装
