### PR TITLE
feat(web): 経年グラフ画面を追加(Issue #28)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Lint
         run: npm --prefix web run lint
 
+      - name: Test
+        run: npm --prefix web run test
+
       - name: Build
         run: npm --prefix web run build

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,7 +5,7 @@
 
 ## 基本方針
 
-- 対象プラットフォーム: Android（min API 26）。Web 版は本書のトークンを参照するが今回の刷新対象外
+- 対象プラットフォーム: Android（min API 26）。Web 版は本書のトークンを参照するが今回の刷新対象外（2026-08-12 追記: Web の経年グラフ画面【Issue #28】以降に追加する Web 新規画面には、下記「Web 版トークン適用方針」を適用する。既存の Web 4画面 `RecordList` / `RecordDetail` / `RecordForm` / `ItemMasters` はカラーコード直書きのまま残っており、本追記の対象外・別タスクでの是正待ち）
 - 準拠ガイドライン: Material Design 3
 - 使用コンポーネントライブラリ: Material Components for Android（XML/View ベース）
 - トーン&マナー: 落ち着いた健康管理ツール。医療データを扱うため誇張のない誠実な配色
@@ -67,6 +67,24 @@
 | S-06a カメラ読み取り | 撮影→OCR確認・補正 | 撮影 / この内容で登録 | ローディング: OCR処理中表示必須 |
 | S-06b 手入力フォーム | 数値入力 | 登録する | エラー: 数値バリデーション |
 | S-07 お問い合わせ | サポート連絡 | 送信（メーラー起動） | エラー: メーラー不在時の案内 |
+
+## Web 版トークン適用方針（2026-08-12 追記, Issue #28）
+
+Web（`web/`）で新規に追加する画面は、Android と同じ意味のトークンを CSS カスタムプロパティとして参照する。カラーコードの直書きは禁止。
+
+- 定義場所: `web/src/index.css` の `:root`（ライト）と `@media (prefers-color-scheme: dark)` 内（ダーク）
+- 命名: `--color-<トークン名>`（Android のトークン表と同じ名前を使う）
+- 現時点で定義済みのトークン（本 Issue で追加）:
+
+| CSS変数 | トークン | ライト | ダーク | 用途 |
+|--------|---------|-------|-------|------|
+| `--color-primary` | primary | #00696C | #4DD8DC | グラフの主線・アクティブなタブなど主要アクション相当 |
+| `--color-error` | error | #BA1A1A | #FFB4AB | 基準値の上限・下限を示す参照線 |
+
+- 通常の CSS（`color` / `background` 等）では `var(--color-primary)` のようにそのまま参照する
+- **Canvas 描画（Chart.js 等）では `var()` がブラウザの Canvas 2D API 上で解決されないため**、`getComputedStyle(document.documentElement).getPropertyValue('--color-primary')` で実測値の文字列を取得してから渡す（`web/src/components/TrendChart.tsx` 参照）
+- 新規トークンが必要になったら、この表と Android 側のカラートークン表の両方に追記し、値を一致させる
+- 既存 4 画面（`RecordList` / `RecordDetail` / `RecordForm` / `ItemMasters`）の直書きカラーコードは本追記の対象外。是正は別タスクで行う
 
 ## プロジェクト固有ルール
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -134,7 +134,7 @@
 
 | チケット | タスク | 担当 | ステータス |
 |---------|--------|------|-----------|
-| T-601 | 経年グラフ（Chart.js） | engineer | 🔍 レビュー待ち（Issue #28, PR作成済み） |
+| T-601 | 経年グラフ（Chart.js） | engineer | 🔍 レビュー待ち（Issue #28, PR #42） |
 | T-602 | 基準値外一覧画面 | engineer | 未着手 |
 | T-603 | Firebase Hostingデプロイ設定 | engineer | 未着手 |
 | T-604 | Firestoreセキュリティルール最終確認 | engineer | 未着手 |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -134,7 +134,7 @@
 
 | チケット | タスク | 担当 | ステータス |
 |---------|--------|------|-----------|
-| T-601 | 経年グラフ（Chart.js） | engineer | 未着手 |
+| T-601 | 経年グラフ（Chart.js） | engineer | 🔍 レビュー待ち（Issue #28, PR作成済み） |
 | T-602 | 基準値外一覧画面 | engineer | 未着手 |
 | T-603 | Firebase Hostingデプロイ設定 | engineer | 未着手 |
 | T-604 | Firestoreセキュリティルール最終確認 | engineer | 未着手 |

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.1",
         "firebase": "^12.11.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -25,7 +26,8 @@
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1203,6 +1205,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
@@ -1558,6 +1566,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1568,6 +1583,24 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1933,6 +1966,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2003,6 +2149,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2100,6 +2256,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2115,6 +2281,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/cliui": {
@@ -2244,6 +2422,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escalade": {
@@ -2442,6 +2627,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2450,6 +2645,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3162,6 +3367,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3214,6 +3429,20 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3297,6 +3526,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3575,6 +3811,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3584,6 +3827,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3637,6 +3894,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3652,6 +3926,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3849,6 +4133,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
@@ -3892,6 +4266,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,9 +7,11 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
+    "chart.js": "^4.5.1",
     "firebase": "^12.11.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -27,6 +29,7 @@
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -400,6 +400,57 @@ h2 {
   box-sizing: border-box;
 }
 
+/* ── 経年グラフ ──────────────────────────────────────── */
+
+.trend-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.trend-item-select {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 14px;
+  background: var(--bg);
+  color: var(--text-h);
+  min-width: 200px;
+}
+
+.trend-period-tabs {
+  display: flex;
+  gap: 4px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 3px;
+}
+
+.trend-tab {
+  background: transparent;
+  border: 1.5px solid transparent;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+/* アクティブ状態は primary トークンの文字色＋枠線で表現し、白文字とのコントラスト計算不要にする */
+.trend-tab.active {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.trend-chart-wrap {
+  position: relative;
+  height: 360px;
+  width: 100%;
+}
+
 /* ── 共通 ──────────────────────────────────────────── */
 
 .msg { color: var(--text); font-size: 15px; padding: 20px 0; }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import RecordList from './pages/RecordList'
 import RecordDetail from './pages/RecordDetail'
 import RecordForm from './pages/RecordForm'
 import ItemMasters from './pages/ItemMasters'
+import TrendGraph from './pages/TrendGraph'
 import './App.css'
 
 function LoginPage() {
@@ -49,6 +50,9 @@ function Layout({ user, children }: { user: User; children: React.ReactNode }) {
           <NavLink to="/masters" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
             項目マスター
           </NavLink>
+          <NavLink to="/trends" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+            経年グラフ
+          </NavLink>
         </div>
         <div className="nav-user">
           {user.photoURL && <img src={user.photoURL} alt="" className="nav-avatar" />}
@@ -86,6 +90,7 @@ export default function App() {
           <Route path="/records/new" element={<RecordForm uid={user.uid} />} />
           <Route path="/records/:id" element={<RecordDetail uid={user.uid} />} />
           <Route path="/masters" element={<ItemMasters uid={user.uid} />} />
+          <Route path="/trends" element={<TrendGraph uid={user.uid} />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Layout>

--- a/web/src/components/TrendChart.tsx
+++ b/web/src/components/TrendChart.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from 'react'
+import {
+  CategoryScale,
+  Chart,
+  Legend,
+  LinearScale,
+  LineController,
+  LineElement,
+  PointElement,
+  Tooltip,
+} from 'chart.js'
+import type { ChartDataset } from 'chart.js'
+
+Chart.register(CategoryScale, LinearScale, LineElement, PointElement, LineController, Tooltip, Legend)
+
+/**
+ * CSS カスタムプロパティ（DESIGN.md「Web 版トークン適用方針」）の実測値を取得する。
+ * Canvas 2D API の strokeStyle/fillStyle は `var(--foo)` を解決できないため、
+ * getComputedStyle 経由で実際のカラーコードに変換してから Chart.js に渡す。
+ */
+function resolveCssColor(varName: string, fallback: string): string {
+  if (typeof document === 'undefined') return fallback
+  const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim()
+  return value || fallback
+}
+
+interface TrendChartProps {
+  itemName: string
+  labels: string[]
+  values: number[]
+  unit: string
+  referenceMin: number | null
+  referenceMax: number | null
+}
+
+/**
+ * 経年グラフの折れ線表示コンポーネント（Issue #28: Chart.js 採用、後から差し替えやすいよう薄くラップ）。
+ * 薬事法対応: 表示するテキストは項目名・単位・日付・数値のみ。医療的な評価・助言の文言は一切表示しない。
+ */
+export default function TrendChart({ itemName, labels, values, unit, referenceMin, referenceMax }: TrendChartProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const chartRef = useRef<Chart<'line', number[], string> | null>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    const primaryColor = resolveCssColor('--color-primary', '#00696C')
+    const errorColor = resolveCssColor('--color-error', '#BA1A1A')
+
+    const datasets: ChartDataset<'line', number[]>[] = [
+      {
+        label: unit ? `${itemName} (${unit})` : itemName,
+        data: values,
+        borderColor: primaryColor,
+        backgroundColor: primaryColor,
+        pointBackgroundColor: primaryColor,
+        tension: 0.15,
+      },
+    ]
+
+    if (referenceMin !== null) {
+      datasets.push({
+        label: '基準値（下限）',
+        data: values.map(() => referenceMin),
+        borderColor: errorColor,
+        backgroundColor: errorColor,
+        pointRadius: 0,
+        borderDash: [6, 4],
+      })
+    }
+    if (referenceMax !== null) {
+      datasets.push({
+        label: '基準値（上限）',
+        data: values.map(() => referenceMax),
+        borderColor: errorColor,
+        backgroundColor: errorColor,
+        pointRadius: 0,
+        borderDash: [6, 4],
+      })
+    }
+
+    chartRef.current?.destroy()
+    chartRef.current = new Chart<'line', number[], string>(canvas, {
+      type: 'line',
+      data: { labels, datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        // 薬事法対応: 凡例・ツールチップは値と日付のみで、判定文言を含まない
+        plugins: {
+          legend: { display: false },
+        },
+        scales: {
+          y: { beginAtZero: false },
+        },
+      },
+    })
+
+    return () => {
+      chartRef.current?.destroy()
+      chartRef.current = null
+    }
+  }, [itemName, labels, values, unit, referenceMin, referenceMax])
+
+  return (
+    <div className="trend-chart-wrap">
+      <canvas ref={canvasRef} role="img" aria-label={`${itemName}の経年グラフ`} />
+    </div>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -11,6 +11,10 @@
   --shadow:
     rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
 
+  /* DESIGN.md「Web 版トークン適用方針」（Issue #28）。Android のカラートークン表と値を一致させる */
+  --color-primary: #00696C;
+  --color-error: #BA1A1A;
+
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
   --mono: ui-monospace, Consolas, monospace;
@@ -43,6 +47,9 @@
     --social-bg: rgba(47, 48, 58, 0.5);
     --shadow:
       rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+
+    --color-primary: #4DD8DC;
+    --color-error: #FFB4AB;
   }
 
   #social .button-icon {

--- a/web/src/lib/trend.test.ts
+++ b/web/src/lib/trend.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TrendPeriod,
+  buildTrendPoints,
+  filterByPeriod,
+  latestReferenceRange,
+  parseNumericValue,
+} from './trend'
+import type { ExaminationRecord } from '../types'
+
+function record(
+  date: string,
+  itemName: string,
+  value: string,
+  overrides: Partial<{ unit: string; referenceMin: number | null; referenceMax: number | null }> = {},
+): ExaminationRecord {
+  return {
+    id: date,
+    date,
+    facility: '',
+    createdAt: 0,
+    items: [
+      {
+        itemName,
+        value,
+        unit: overrides.unit ?? '',
+        referenceMin: overrides.referenceMin ?? null,
+        referenceMax: overrides.referenceMax ?? null,
+        isAbnormal: false,
+      },
+    ],
+  }
+}
+
+describe('parseNumericValue', () => {
+  it('数値文字列を数値化する', () => {
+    expect(parseNumericValue('22.5')).toBe(22.5)
+  })
+
+  it('数値化できない文字列は null を返す', () => {
+    expect(parseNumericValue('陰性')).toBeNull()
+  })
+
+  it('空文字は null を返す', () => {
+    expect(parseNumericValue('')).toBeNull()
+  })
+
+  it('Issue #28 の決定: parseFloat 相当のため先頭が数値なら変換できる', () => {
+    expect(parseNumericValue('12kg')).toBe(12)
+  })
+})
+
+describe('buildTrendPoints', () => {
+  it('指定した項目名のデータ点のみを日付昇順で抽出する', () => {
+    const records: ExaminationRecord[] = [
+      record('2026-06-01', 'BMI', '22.0'),
+      record('2025-06-01', 'BMI', '21.0'),
+      record('2025-06-01', '血圧', '120'),
+    ]
+    const points = buildTrendPoints(records, 'BMI')
+    expect(points.map(p => p.date)).toEqual(['2025-06-01', '2026-06-01'])
+    expect(points.map(p => p.value)).toEqual([21.0, 22.0])
+  })
+
+  it('数値化できない値は除外する', () => {
+    const records: ExaminationRecord[] = [
+      record('2026-06-01', 'HBs抗原', '陰性'),
+      record('2026-07-01', 'HBs抗原', '1.2'),
+    ]
+    const points = buildTrendPoints(records, 'HBs抗原')
+    expect(points.map(p => p.date)).toEqual(['2026-07-01'])
+  })
+
+  it('記録0件のときは空配列を返す', () => {
+    expect(buildTrendPoints([], 'BMI')).toEqual([])
+  })
+
+  it('該当項目が0件のときは空配列を返す', () => {
+    const records: ExaminationRecord[] = [record('2026-06-01', '血圧', '120')]
+    expect(buildTrendPoints(records, 'BMI')).toEqual([])
+  })
+})
+
+describe('filterByPeriod', () => {
+  const today = new Date(2026, 6, 19) // 2026-07-19（Android側テストと同じ基準日）
+
+  it('全期間はすべてのデータを返す', () => {
+    const points = buildTrendPoints(
+      [record('2020-01-01', 'BMI', '22'), record('2025-06-01', 'BMI', '22'), record('2026-06-01', 'BMI', '22')],
+      'BMI',
+    )
+    expect(filterByPeriod(points, TrendPeriod.ALL, today)).toHaveLength(3)
+  })
+
+  it('1年は今日から1年以内（境界日を含む）のデータのみ返す', () => {
+    const points = buildTrendPoints(
+      [
+        record('2020-01-01', 'BMI', '22'),
+        record('2025-07-18', 'BMI', '22'), // 1年+1日前 → 除外
+        record('2025-07-19', 'BMI', '22'), // ちょうど1年前 → 含む
+        record('2026-06-01', 'BMI', '22'),
+      ],
+      'BMI',
+    )
+    const filtered = filterByPeriod(points, TrendPeriod.ONE_YEAR, today)
+    expect(filtered.map(p => p.date)).toEqual(['2025-07-19', '2026-06-01'])
+  })
+
+  it('日付として解釈できない行は1年フィルタで除外される', () => {
+    const points = [
+      { date: '不正な日付', value: 22, unit: '', referenceMin: null, referenceMax: null },
+      { date: '2026-06-01', value: 22, unit: '', referenceMin: null, referenceMax: null },
+    ]
+    const filtered = filterByPeriod(points, TrendPeriod.ONE_YEAR, today)
+    expect(filtered.map(p => p.date)).toEqual(['2026-06-01'])
+  })
+
+  it('うるう日の1年前は非うるう年では2/28にクランプする', () => {
+    const leapDayToday = new Date(2028, 1, 29) // 2028-02-29（うるう年）
+    const points = [
+      { date: '2027-02-28', value: 1, unit: '', referenceMin: null, referenceMax: null },
+      { date: '2027-03-01', value: 1, unit: '', referenceMin: null, referenceMax: null },
+    ]
+    const filtered = filterByPeriod(points, TrendPeriod.ONE_YEAR, leapDayToday)
+    expect(filtered.map(p => p.date)).toEqual(['2027-02-28', '2027-03-01'])
+  })
+})
+
+describe('latestReferenceRange', () => {
+  it('直近の記録の基準値を返す', () => {
+    const points = [
+      { date: '2025-01-01', value: 1, unit: '', referenceMin: 1, referenceMax: 2 },
+      { date: '2026-01-01', value: 1, unit: '', referenceMin: 3, referenceMax: 4 },
+    ]
+    expect(latestReferenceRange(points)).toEqual({ referenceMin: 3, referenceMax: 4 })
+  })
+
+  it('直近の記録に基準値がない場合は遡って探す', () => {
+    const points = [
+      { date: '2025-01-01', value: 1, unit: '', referenceMin: 1, referenceMax: 2 },
+      { date: '2026-01-01', value: 1, unit: '', referenceMin: null, referenceMax: null },
+    ]
+    expect(latestReferenceRange(points)).toEqual({ referenceMin: 1, referenceMax: 2 })
+  })
+
+  it('基準値が1件もない場合は null/null を返す', () => {
+    const points = [{ date: '2025-01-01', value: 1, unit: '', referenceMin: null, referenceMax: null }]
+    expect(latestReferenceRange(points)).toEqual({ referenceMin: null, referenceMax: null })
+  })
+
+  it('データなしの場合は null/null を返す', () => {
+    expect(latestReferenceRange([])).toEqual({ referenceMin: null, referenceMax: null })
+  })
+})

--- a/web/src/lib/trend.ts
+++ b/web/src/lib/trend.ts
@@ -1,0 +1,132 @@
+// Issue #28: Web 版経年グラフのロジック（数値変換・期間フィルタ）を UI から分離したモジュール。
+// Android の ui/graph/TrendPeriodFilter.kt・TrendGraphFragment.kt と同じ結果になるよう実装している。
+// 相違点（PR本文にも明記）:
+//   - 数値変換は Issue #28 の決定により Android の toDoubleOrNull ではなく parseFloat 相当を採用する
+//     （"12abc" のような文字列も 12 として数値化される点が toDoubleOrNull と異なる）
+//   - 基準値の参照線は「直近の記録で referenceMin/Max が設定されている値」を使う
+//     （Android は経年データの先頭行=最も古い記録の値を使っており、そちらは実質バグに近いため web では最新値を採用）
+import type { ExaminationRecord } from '../types'
+
+/** S-04 グラフの期間切替（Android TrendPeriod と同じ「1年 / 全期間」の2値） */
+export const TrendPeriod = {
+  ONE_YEAR: 'ONE_YEAR',
+  ALL: 'ALL',
+} as const
+
+export type TrendPeriod = (typeof TrendPeriod)[keyof typeof TrendPeriod]
+
+/** 検査項目1件・記録1件分のグラフ用データ点 */
+export interface TrendPoint {
+  date: string // "yyyy-MM-dd"
+  value: number
+  unit: string
+  referenceMin: number | null
+  referenceMax: number | null
+}
+
+/**
+ * 検査値の文字列を数値化する。
+ * 「陰性」など数値化できない値は null を返し、呼び出し側でグラフから除外する。
+ * Issue #28 の決定: Android の toDoubleOrNull ではなく parseFloat 相当で判定する。
+ */
+export function parseNumericValue(raw: string): number | null {
+  const parsed = parseFloat(raw)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+/**
+ * 診断記録の一覧から、指定した検査項目名のグラフ用データ点を抽出する。
+ * 数値化できない値は除外し、日付昇順（古い→新しい）に並べる。
+ */
+export function buildTrendPoints(records: ExaminationRecord[], itemName: string): TrendPoint[] {
+  const points: TrendPoint[] = []
+  for (const record of records) {
+    const item = record.items.find(i => i.itemName === itemName)
+    if (!item) continue
+    const value = parseNumericValue(item.value)
+    if (value === null) continue
+    points.push({
+      date: record.date,
+      value,
+      unit: item.unit,
+      referenceMin: item.referenceMin,
+      referenceMax: item.referenceMax,
+    })
+  }
+  return [...points].sort((a, b) => a.date.localeCompare(b.date))
+}
+
+interface CalendarDate {
+  y: number
+  m: number // 1-12
+  d: number
+}
+
+/** "yyyy-MM-dd" を厳密に検証してパースする（LocalDate.parse と同様に不正な日付は null） */
+function parseIsoDate(value: string): CalendarDate | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return null
+  const y = Number(match[1])
+  const m = Number(match[2])
+  const d = Number(match[3])
+  const roundTrip = new Date(y, m - 1, d)
+  if (roundTrip.getFullYear() !== y || roundTrip.getMonth() !== m - 1 || roundTrip.getDate() !== d) {
+    return null
+  }
+  return { y, m, d }
+}
+
+function isLeapYear(y: number): boolean {
+  return (y % 4 === 0 && y % 100 !== 0) || y % 400 === 0
+}
+
+/** LocalDate.minusYears(1) と同じ挙動（うるう日は非うるう年では2/28にクランプ） */
+function oneYearBefore(date: CalendarDate): CalendarDate {
+  const y = date.y - 1
+  if (date.m === 2 && date.d === 29 && !isLeapYear(y)) {
+    return { y, m: 2, d: 28 }
+  }
+  return { y, m: date.m, d: date.d }
+}
+
+function dateKey(date: CalendarDate): number {
+  return date.y * 10000 + date.m * 100 + date.d
+}
+
+/**
+ * 期間でグラフ用データ点を絞り込む。
+ * ALL: すべて返す。ONE_YEAR: 今日から1年以内（境界日を含む）のみ返し、
+ * 日付として解釈できない行は除外する（Android TrendPeriodFilter.filter と同じ）。
+ */
+export function filterByPeriod(
+  points: TrendPoint[],
+  period: TrendPeriod,
+  today: Date = new Date(),
+): TrendPoint[] {
+  if (period === TrendPeriod.ALL) return points
+
+  const cutoff = oneYearBefore({ y: today.getFullYear(), m: today.getMonth() + 1, d: today.getDate() })
+  const cutoffKey = dateKey(cutoff)
+
+  return points.filter(point => {
+    const parsed = parseIsoDate(point.date)
+    return parsed !== null && dateKey(parsed) >= cutoffKey
+  })
+}
+
+/**
+ * 参照線用の基準値を返す。referenceMin/Max が設定されている直近の記録の値を採用する。
+ * すべて未設定の場合は null/null を返す（呼び出し側で参照線を描画しない）。
+ */
+export function latestReferenceRange(points: TrendPoint[]): {
+  referenceMin: number | null
+  referenceMax: number | null
+} {
+  for (let i = points.length - 1; i >= 0; i -= 1) {
+    const point = points[i]
+    if (point.referenceMin !== null || point.referenceMax !== null) {
+      return { referenceMin: point.referenceMin, referenceMax: point.referenceMax }
+    }
+  }
+  return { referenceMin: null, referenceMax: null }
+}

--- a/web/src/pages/TrendGraph.tsx
+++ b/web/src/pages/TrendGraph.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useState } from 'react'
+import { fetchMasters, fetchRecords } from '../firestoreService'
+import type { ExaminationRecord, ItemMaster } from '../types'
+import { TrendPeriod, buildTrendPoints, filterByPeriod, latestReferenceRange } from '../lib/trend'
+import TrendChart from '../components/TrendChart'
+
+interface Props { uid: string }
+
+/**
+ * US-W04 / T-601: Web版 経年グラフ画面。
+ * 選択した検査項目の値の推移を折れ線グラフで表示する（Android S-04 相当）。
+ * 薬事法対応: 医療的な評価・助言・改善提案の文言は一切表示しない（docs/compliance.md 参照）。
+ */
+export default function TrendGraph({ uid }: Props) {
+  const [records, setRecords] = useState<ExaminationRecord[]>([])
+  const [masters, setMasters] = useState<ItemMaster[]>([])
+  const [loading, setLoading] = useState(true)
+  const [itemName, setItemName] = useState('')
+  const [period, setPeriod] = useState<TrendPeriod>(TrendPeriod.ALL)
+
+  useEffect(() => {
+    Promise.all([fetchRecords(uid), fetchMasters(uid)])
+      .then(([r, m]) => {
+        setRecords(r)
+        setMasters(m)
+      })
+      .finally(() => setLoading(false))
+  }, [uid])
+
+  // 選択可能な項目名: マスター登録済み項目 + 記録に含まれる項目名（マスター未登録でも選べるようにする）
+  const itemNames = useMemo(() => {
+    const names = new Set<string>()
+    masters.forEach(m => names.add(m.itemName))
+    records.forEach(r => r.items.forEach(i => names.add(i.itemName)))
+    return Array.from(names).sort((a, b) => a.localeCompare(b, 'ja'))
+  }, [masters, records])
+
+  // 選択中の項目が存在しない（未選択・記録更新で消えた等）場合は先頭の項目にフォールバックする。
+  // useEffect+setState で同期するとカスケード再レンダーになるため、派生値として計算する。
+  const selectedItemName = itemNames.includes(itemName) ? itemName : (itemNames[0] ?? '')
+
+  const allPoints = useMemo(
+    () => (selectedItemName ? buildTrendPoints(records, selectedItemName) : []),
+    [records, selectedItemName],
+  )
+  const points = useMemo(() => filterByPeriod(allPoints, period), [allPoints, period])
+  const { referenceMin, referenceMax } = useMemo(() => latestReferenceRange(allPoints), [allPoints])
+
+  if (loading) return <p className="msg">読み込み中...</p>
+
+  return (
+    <div>
+      <h2>経年グラフ</h2>
+      <p className="note-small">検査項目を選択すると、記録済みの値の推移を確認できます。</p>
+
+      {itemNames.length === 0 ? (
+        <p className="msg">記録がありません。「記録一覧」から登録してください。</p>
+      ) : (
+        <>
+          <div className="trend-controls">
+            <select
+              className="trend-item-select"
+              value={selectedItemName}
+              onChange={e => setItemName(e.target.value)}
+              aria-label="検査項目"
+            >
+              {itemNames.map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+
+            <div className="trend-period-tabs" role="tablist" aria-label="期間">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={period === TrendPeriod.ONE_YEAR}
+                className={period === TrendPeriod.ONE_YEAR ? 'trend-tab active' : 'trend-tab'}
+                onClick={() => setPeriod(TrendPeriod.ONE_YEAR)}
+              >
+                1年
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={period === TrendPeriod.ALL}
+                className={period === TrendPeriod.ALL ? 'trend-tab active' : 'trend-tab'}
+                onClick={() => setPeriod(TrendPeriod.ALL)}
+              >
+                全期間
+              </button>
+            </div>
+          </div>
+
+          {points.length === 0 ? (
+            <p className="msg">この項目・期間で表示できる記録がありません。</p>
+          ) : (
+            <TrendChart
+              itemName={selectedItemName}
+              labels={points.map(p => p.date)}
+              values={points.map(p => p.value)}
+              unit={points[points.length - 1].unit}
+              referenceMin={referenceMin}
+              referenceMax={referenceMax}
+            />
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'node',
+  },
 })


### PR DESCRIPTION
Closes #28

## 概要

Web版に検査項目の経年グラフ画面（`/trends`）を追加し、US-W04（Webでの推移確認）と T-601 を実装した。

- 項目マスター＋記録内の項目名から検査項目を選択すると、その項目の値の推移を日付昇順の折れ線グラフで表示する
- 基準値（referenceMin/referenceMax）が設定されている場合は上限・下限を参照線として重ねる
- 期間タブ「1年」「全期間」を切り替えられる（Android の `TrendPeriodFilter` と同じ結果になるようテストで確認済み）
- 数値に変換できない値（「陰性」等）はグラフから除外する
- 記録が0件、または数値化できる値が0件の場合は空状態メッセージを表示する（クラッシュ・空白画面なし）
- 薬事法対応: グラフ・凡例・ツールチップに医療的助言・評価・改善提案の文言は含めていない

## 無人実行で決めた設計判断（Issue本文の未解決の質問への回答）

1. **グラフライブラリ: Chart.js を採用**（backlog の既定どおり）。`web/src/components/TrendChart.tsx` に薄いラッパーとして実装し、後から別ライブラリに差し替えやすい構造にした。
2. **テストランナー: vitest を新規導入**。`web/package.json` に `test` スクリプトを追加し、`.github/workflows/web-ci.yml` にも `Test` ステップを追加（lintとbuildの間）。数値変換・期間フィルタのロジックは `web/src/lib/trend.ts` にUIから分離し、`web/src/lib/trend.test.ts` で16件の単体テストを追加（Androidの `TrendPeriodFilterTest.kt` と同じ境界値・不正日付ケースを含む）。
3. **T-602（基準値外一覧画面）はスコープ外**。Issue #33 の担当であり、本PRでは触っていない。

## Android実装との相違点（意図的な差分）

- **数値変換**: Issue #28 の指示に従い `parseFloat` 相当（`web/src/lib/trend.ts` の `parseNumericValue`）を採用した。Android の `HealthRepository.evaluateAbnormal` は `toDoubleOrNull`（厳密なパース）を使っているため、例えば `"12kg"` のような値は Android では非数値扱いだが Web では `12` として数値化される。
- **参照線の基準値**: Web は「referenceMin/Max が設定されている直近の記録」の値を参照線に使う（`latestReferenceRange`）。Android の `TrendGraphFragment.renderGraph` は経年データの先頭行（＝最も古い記録）の値を使っており、これは実質的にバグに近い挙動と判断し、Web では最新値を採用した。

## デザイン（DESIGN.md）

- DESIGN.md に「Web 版トークン適用方針」を追記し、`primary` / `error` トークンを `web/src/index.css` の CSS カスタムプロパティ（`--color-primary` / `--color-error`、ライト/ダーク）として定義した。値はAndroid側のカラートークン表と一致させている。
- Chart.js の Canvas 2D API は `var(--foo)` を解決できないため、`getComputedStyle` で実測値に変換してから渡している（`TrendChart.tsx` 内 `resolveCssColor`、DESIGN.md にも明記）。
- 既存の Web 4画面（`RecordList` / `RecordDetail` / `RecordForm` / `ItemMasters`）はカラーコード直書きのままで、本PRの対象外（是正は別タスク）。

## 動作確認

- `npm --prefix web run test` … 16件全てパス
- `npm --prefix web run lint` … エラー0件（既存の `ItemMasters.tsx` の警告1件は本PR対象外、変更なし）
- `npm --prefix web run build` … 成功
- ブラウザでの実機確認は未実施（Google SSO 認証が必要で無人実行環境では完了できないため）。ロジックはユニットテストで検証済み。

## その他

- `docs/backlog.md` の T-601 のステータスを更新（PR番号はマージ前のためレビュー待ち表記、後続コミットでPR番号を補記予定）
- 画像アセットは今回追加していない
