### PR TITLE
feat: サインアウト時にRoom DBの健診データを消去する(Issue #41)

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
@@ -9,7 +9,9 @@ import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
 import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
 import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 
 /**
  * 健康診断データの Repository。
@@ -151,6 +153,34 @@ class HealthRepository(
      */
     fun getAllAbnormalItems(): Flow<List<ExaminationItem>> =
         db.itemDao().getAllAbnormalItems()
+
+    /**
+     * Issue #41: サインアウト時に端末の Room DB から健診データを消去する。
+     *
+     * 共用端末でサインアウトしても前の利用者の健診記録・項目マスターのカスタマイズ
+     * （基準値編集・お気に入り等）が閲覧できてしまう問題への対応。
+     * アカウント削除（Issue #34, `AccountDeletionManager.deleteAllLocalHealthData`）とは別処理:
+     * こちらは削除確認ダイアログを伴わないサインアウトの一部として、既存UXを変えずに実行する。
+     *
+     * `db.clearAllTables()` は診断記録・検査項目・項目マスターの全テーブルを消去するが、
+     * DB作成時のみ実行される `PREPOPULATE_CALLBACK` は再実行されないため、
+     * 項目マスターは [HealthCheckupDatabase.DEFAULT_ITEM_MASTERS] を明示的に再投入し、
+     * 端末を初期状態のカタログへ戻す（削除ではなく「初期化」）。
+     *
+     * 再度同じアカウントでサインインすると `LoginViewModel.signIn()` 経由で
+     * [restoreFromFirestore] が呼ばれ、Firestore に保存済みの記録・カスタマイズ済み項目マスターが
+     * itemName をキーに上書き復元される（Firestoreにない項目は初期値のまま残る＝データ喪失にはならない）。
+     *
+     * clearAllTables() はメインスレッドで呼べないため IO ディスパッチャ上で実行する。
+     */
+    suspend fun clearLocalDataOnSignOut() {
+        withContext(Dispatchers.IO) {
+            db.clearAllTables()
+            HealthCheckupDatabase.DEFAULT_ITEM_MASTERS.forEach { master ->
+                db.masterDao().upsert(master)
+            }
+        }
+    }
 
     /**
      * T-403: Firestoreから全データを取得してRoomへ復元する。

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/ui/home/HomeFragment.kt
@@ -10,12 +10,15 @@ import android.view.ViewGroup
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseAuth
+import com.rokusoudo.healthcheckup.HealthCheckupApp
 import com.rokusoudo.healthcheckup.R
 import com.rokusoudo.healthcheckup.databinding.FragmentHomeBinding
+import kotlinx.coroutines.launch
 
 /**
  * S-02 ホーム画面。「登録」「グラフ」「お問い合わせ」への分岐ハブ。
@@ -83,14 +86,24 @@ class HomeFragment : Fragment() {
         }, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
+    /**
+     * Issue #41: サインアウト時、共用端末に前の利用者の健診データが残らないよう
+     * 端末の Room DB もあわせて消去する（削除確認ダイアログ等は不要。既存UXは変えない）。
+     * Room クリアは suspend 処理のため、ライフサイクルに紐づくコルーチンから呼び出す。
+     */
     private fun signOut() {
-        // Firebase Auth からサインアウト
-        FirebaseAuth.getInstance().signOut()
-        // Google Sign-In のキャッシュもクリア
-        val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
-        GoogleSignIn.getClient(requireActivity(), gso).signOut()
-        // ログイン画面へ遷移（バックスタックを消去）
-        findNavController().navigate(R.id.action_home_to_login)
+        val repository = (requireActivity().application as HealthCheckupApp).repository
+        viewLifecycleOwner.lifecycleScope.launch {
+            // 端末の Room DB から健診データを消去（Firestore上のデータには影響しない）
+            repository.clearLocalDataOnSignOut()
+            // Firebase Auth からサインアウト
+            FirebaseAuth.getInstance().signOut()
+            // Google Sign-In のキャッシュもクリア
+            val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
+            GoogleSignIn.getClient(requireActivity(), gso).signOut()
+            // ログイン画面へ遷移（バックスタックを消去）
+            findNavController().navigate(R.id.action_home_to_login)
+        }
     }
 
     override fun onDestroyView() {

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositorySignOutTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositorySignOutTest.kt
@@ -1,0 +1,171 @@
+package com.rokusoudo.healthcheckup.data.repository
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
+import com.rokusoudo.healthcheckup.data.db.entity.ItemCategories
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #41: サインアウト時の Room DB クリア（[HealthRepository.clearLocalDataOnSignOut]）を検証する。
+ *
+ * - サインアウト後、端末の Room DB に健診データ（記録・検査項目）が残っていないこと
+ * - 項目マスターは削除されたままにはせず、初期カタログ（DEFAULT_ITEM_MASTERS）へ戻ること
+ *   （カスタマイズ済みの基準値・お気に入り状態は消える＝前の利用者の情報を残さない）
+ * - 再度同じアカウントでサインインした場合、Firestoreに保存済みのデータで復元されること
+ * - 何もデータが無い状態で呼び出しても例外にならないこと（冪等）
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class HealthRepositorySignOutTest {
+
+    private lateinit var db: HealthCheckupDatabase
+    private lateinit var cloudSync: FakeHealthCloudSync
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            HealthCheckupDatabase::class.java
+        ).allowMainThreadQueries().build()
+        cloudSync = FakeHealthCloudSync()
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    @Test
+    fun `サインアウト後は記録と検査項目がRoomDBに残らない`() = runBlocking {
+        val recordId = db.recordDao().insert(
+            ExaminationRecord(date = "2026-08-01", facility = "六創堂クリニック", createdAt = 1000L)
+        )
+        db.itemDao().insertAll(
+            listOf(
+                ExaminationItem(
+                    recordId = recordId,
+                    itemName = "LDLコレステロール",
+                    value = "150",
+                    unit = "mg/dL",
+                    referenceMin = null,
+                    referenceMax = 139.0,
+                    isAbnormal = true
+                )
+            )
+        )
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+
+        repository.clearLocalDataOnSignOut()
+
+        assertNull(db.recordDao().getById(recordId))
+        assertTrue(db.itemDao().getByRecordIdOnce(recordId).isEmpty())
+    }
+
+    @Test
+    fun `サインアウト後は項目マスターが初期カタログへ戻りカスタマイズは残らない`() = runBlocking {
+        // 前の利用者が基準値・カテゴリをカスタマイズした項目マスター
+        db.masterDao().upsert(
+            ItemMaster(
+                itemName = "LDLコレステロール",
+                unit = "mg/dL",
+                referenceMin = 50.0,
+                referenceMax = 999.0,
+                category = ItemCategories.OTHER,
+                isFavorite = true,
+                favoritedAt = 12345L
+            )
+        )
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+
+        repository.clearLocalDataOnSignOut()
+
+        val masters = db.masterDao().getAll().first()
+        assertEquals(HealthCheckupDatabase.DEFAULT_ITEM_MASTERS.size, masters.size)
+        val ldl = masters.first { it.itemName == "LDLコレステロール" }
+        // カスタマイズ（基準値・お気に入り）は消え、初期カタログの値に戻っている
+        assertEquals(139.0, ldl.referenceMax)
+        assertEquals(false, ldl.isFavorite)
+        assertNull(ldl.favoritedAt)
+    }
+
+    @Test
+    fun `サインアウト後に同じアカウントで再ログインするとFirestoreからデータが復元される`() = runBlocking {
+        db.recordDao().insert(ExaminationRecord(date = "2026-08-01", facility = "旧データ", createdAt = 1000L))
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+        repository.clearLocalDataOnSignOut()
+
+        // Firestoreには記録とカスタマイズ済み項目マスターが保存されている想定
+        cloudSync.recordsToReturn = listOf(
+            ExaminationRecord(id = 1L, date = "2026-08-01", facility = "六創堂クリニック", createdAt = 2000L) to
+                listOf(
+                    ExaminationItem(
+                        recordId = 1L,
+                        itemName = "LDLコレステロール",
+                        value = "150",
+                        unit = "mg/dL",
+                        referenceMin = null,
+                        referenceMax = 139.0,
+                        isAbnormal = true
+                    )
+                )
+        )
+        cloudSync.mastersToReturn = listOf(
+            ItemMaster("LDLコレステロール", "mg/dL", null, 139.0, isFavorite = true, favoritedAt = 5000L)
+        )
+
+        repository.restoreFromFirestore("test-uid")
+
+        val restoredRecord = db.recordDao().getById(1L)
+        assertTrue(restoredRecord != null)
+        assertEquals("六創堂クリニック", restoredRecord!!.facility)
+        val restoredMaster = db.masterDao().getByName("LDLコレステロール")
+        assertTrue(restoredMaster != null)
+        assertEquals(true, restoredMaster!!.isFavorite)
+    }
+
+    @Test
+    fun `データが無い状態でサインアウト処理を呼んでも例外にならない`() = runBlocking {
+        val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
+
+        repository.clearLocalDataOnSignOut()
+
+        val masters = db.masterDao().getAll().first()
+        assertEquals(HealthCheckupDatabase.DEFAULT_ITEM_MASTERS.size, masters.size)
+    }
+
+    private class FakeHealthCloudSync : HealthCloudSync {
+        var recordsToReturn: List<Pair<ExaminationRecord, List<ExaminationItem>>> = emptyList()
+        var mastersToReturn: List<ItemMaster> = emptyList()
+
+        override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
+            // 本テストでは未使用
+        }
+
+        override suspend fun saveItemMaster(uid: String, master: ItemMaster) {
+            // 本テストでは未使用
+        }
+
+        override suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> {
+            return recordsToReturn
+        }
+
+        override suspend fun fetchItemMasters(uid: String): List<ItemMaster> {
+            return mastersToReturn
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Closes #41

サインアウト実行時に、端末の Room DB に保存された健診データ（診断記録・検査項目・項目マスター）を消去するようにしました。共用端末でサインアウトしても前の利用者の健診データが引き続き閲覧できてしまう問題への対応です。

**Issue #34（アカウントとクラウドデータの削除, PR #44）とは別の処理です。** 削除確認ダイアログ等は追加しておらず、既存のサインアウトのUXは変えていません。

## 実装内容

- `HealthRepository.clearLocalDataOnSignOut()` を追加
  - `db.clearAllTables()` で診断記録・検査項目・項目マスターの全テーブルを消去
  - 項目マスターは `HealthCheckupDatabase.DEFAULT_ITEM_MASTERS` で初期カタログへ再投入（**判断点**: 項目マスターは削除したままにせず、初期状態へ戻す方針にしました。理由は、初期投入時のデフォルト項目マスターはこれまで一度も Firestore に保存されておらず、`upsertMaster()` で明示的に編集された項目のみが Firestore 側に存在するため、消去したままだと再ログイン後にカタログが空になってしまうためです。前の利用者がカスタマイズした基準値・お気に入り状態は消え、初期値に戻ります）
  - `clearAllTables()` はメインスレッドで呼べないため `Dispatchers.IO` 上で実行
- `HomeFragment.signOut()` を `viewLifecycleOwner.lifecycleScope.launch` に変更し、Firebase/Googleサインアウトの前に `clearLocalDataOnSignOut()` を呼ぶよう修正
- 再ログイン時のFirestoreからの復元は、既存の `LoginViewModel.signIn()` → `HealthRepository.restoreFromFirestore()` のフローがそのまま使われます（コード変更不要。`itemName` が項目マスターの主キーのため、Firestore側にカスタマイズが存在すれば初期値の上に上書き復元されます）

### Issue #34（PR #44）との非衝突について

PR #44 は `deleteAllLocalHealthData()` を `HealthRepository.kt` の末尾（`resyncOnStartupIfNeeded()` の直後）に追加し、`ExaminationItemDao` / `ExaminationRecordDao` に `deleteAll()` を追記しています。本PRはDAOには一切手を加えず、`HealthRepository.kt` 内でも別の箇所（`restoreFromFirestore()` の直前）に新メソッドを配置しているため、#44 が未マージの状態でも本PRは独立してマージ可能です。

## テスト

`HealthRepositorySignOutTest.kt` を新規追加し、以下を検証しています。

- サインアウト後、記録・検査項目がRoom DBに残らないこと
- サインアウト後、項目マスターが初期カタログ（DEFAULT_ITEM_MASTERS）へ戻り、カスタマイズ（基準値・お気に入り）が残らないこと
- サインアウト後に同じアカウントで再ログイン（`restoreFromFirestore`）すると、Firestoreに保存済みの記録・カスタマイズ済み項目マスターが復元されること
- データが無い状態で呼び出しても例外にならないこと（冪等）

`./gradlew :app:testDebugUnitTest` で全テスト（新規4件含む）がパスすることを確認済みです。

## 受け入れ基準チェック

- [x] サインアウト実行後、端末の Room DB に健診データが残っていない
- [x] 再度同じアカウントでサインインすると、Firestoreからデータが復元される
- [x] サインアウト処理のユニットテストがある
- [x] アカウント削除（Issue #34）とは別の処理であり、削除確認ダイアログ等は追加していない（既存UXを変えない）
