### PR TITLE
Web版のカラートークン基盤を整備し、ライト固定にする (#56)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -5,7 +5,7 @@
 
 ## 基本方針
 
-- 対象プラットフォーム: Android（min API 26）。Web 版は本書のトークンを参照するが今回の刷新対象外（2026-08-12 追記: Web の経年グラフ画面【Issue #28】以降に追加する Web 新規画面には、下記「Web 版トークン適用方針」を適用する。既存の Web 4画面 `RecordList` / `RecordDetail` / `RecordForm` / `ItemMasters` はカラーコード直書きのまま残っており、本追記の対象外・別タスクでの是正待ち）
+- 対象プラットフォーム: Android（min API 26）。Web 版は本書のトークンを参照するが今回の刷新対象外（2026-08-12 追記: Web の経年グラフ画面【Issue #28】以降に追加する Web 新規画面には、下記「Web 版トークン適用方針」を適用する。2026-09-08 追記: 既存 Web 4画面のうち `ItemMasters` と経年グラフ画面は既にトークン化済みで直書きは0件。残る `RecordList` / `RecordDetail` / `RecordForm` のカラーコード直書きの是正は、トークン基盤を整備する Issue #56 を前提として、画面別の後続 Issue #57（共通シャーシ）・#58（ログイン画面）・#59（記録一覧）・#60（記録詳細・入力フォーム）が担当する）
 - 準拠ガイドライン: Material Design 3
 - 使用コンポーネントライブラリ: Material Components for Android（XML/View ベース）
 - トーン&マナー: 落ち着いた健康管理ツール。医療データを扱うため誇張のない誠実な配色
@@ -23,6 +23,7 @@
 | warning | #B8860B | #FFD54F | 注意 |
 | success | #2E7D32 | #81C784 | 成功 |
 | favorite | #D32F2F | #EF5350 | お気に入り♥（ON時） |
+| outline | #e5e4e7 | 未定義 | 枠線（2026-09-08 追記, Issue #56。Web の `--border` 用に新設。現行 Web の値 `#e5e4e7` をそのまま採用し、背景 `#FAFDFC` に対して枠線として視認できることを確認した。Android では未使用のためダーク値は未定義） |
 
 ### カテゴリカラー（検査項目の文字・枠色。2026-07-18 決定 Q1）
 
@@ -68,23 +69,34 @@
 | S-06b 手入力フォーム | 数値入力 | 登録する | エラー: 数値バリデーション |
 | S-07 お問い合わせ | サポート連絡 | 送信（メーラー起動） | エラー: メーラー不在時の案内 |
 
-## Web 版トークン適用方針（2026-08-12 追記, Issue #28）
+## Web 版トークン適用方針（2026-08-12 追記, Issue #28。2026-09-08 改訂, Issue #56）
 
 Web（`web/`）で新規に追加する画面は、Android と同じ意味のトークンを CSS カスタムプロパティとして参照する。カラーコードの直書きは禁止。
 
-- 定義場所: `web/src/index.css` の `:root`（ライト）と `@media (prefers-color-scheme: dark)` 内（ダーク）
+- **Web はライト固定であり、ダークモードは対象外**（2026-09-08 代表判断）。`web/src/index.css` の `:root` に `color-scheme: light` を明示し、`@media (prefers-color-scheme: dark)` によるトークンのダーク値定義は行わない。
+  Android は `res/values/colors.xml` / `res/values-night/colors.xml` の2本立てでダークモードに対応しているため、**Android はダーク対応・Web はライト固定**という差異が生じる。これは意図した判断であり、Web のダーク対応漏れではない。
+- 定義場所: `web/src/index.css` の `:root`（ライト値のみ）
 - 命名: `--color-<トークン名>`（Android のトークン表と同じ名前を使う）
-- 現時点で定義済みのトークン（本 Issue で追加）:
+- 現時点で定義済みのトークン（ライト値のみ。Issue #56 で `primary` / `error` 以外を追加）:
 
-| CSS変数 | トークン | ライト | ダーク | 用途 |
-|--------|---------|-------|-------|------|
-| `--color-primary` | primary | #00696C | #4DD8DC | グラフの主線・アクティブなタブなど主要アクション相当 |
-| `--color-error` | error | #BA1A1A | #FFB4AB | 基準値の上限・下限を示す参照線 |
+| CSS変数 | トークン | ライト | 用途 |
+|--------|---------|-------|------|
+| `--color-primary` | primary | #00696C | グラフの主線・アクティブなタブなど主要アクション相当 |
+| `--color-background` | background | #FAFDFC | 画面背景 |
+| `--color-surface` | surface | #FFFFFF | カード・パネル |
+| `--color-text-primary` | text-primary | #191C1C | 本文 |
+| `--color-text-secondary` | text-secondary | #3F4948 | 補助テキスト |
+| `--color-error` | error | #BA1A1A | 基準値の上限・下限を示す参照線 |
+| `--color-warning` | warning | #B8860B | 注意 |
+| `--color-success` | success | #2E7D32 | 成功 |
+| `--color-favorite` | favorite | #D32F2F | お気に入り♥（ON時） |
+| `--color-outline` | outline | #e5e4e7 | 枠線 |
 
 - 通常の CSS（`color` / `background` 等）では `var(--color-primary)` のようにそのまま参照する
 - **Canvas 描画（Chart.js 等）では `var()` がブラウザの Canvas 2D API 上で解決されないため**、`getComputedStyle(document.documentElement).getPropertyValue('--color-primary')` で実測値の文字列を取得してから渡す（`web/src/components/TrendChart.tsx` 参照）
 - 新規トークンが必要になったら、この表と Android 側のカラートークン表の両方に追記し、値を一致させる
-- 既存 4 画面（`RecordList` / `RecordDetail` / `RecordForm` / `ItemMasters`）の直書きカラーコードは本追記の対象外。是正は別タスクで行う
+- 既存 Web 4画面のうち `ItemMasters` と経年グラフ画面は既にトークン化済みで直書きは0件。残る `RecordList` / `RecordDetail` / `RecordForm` の直書きカラーコードの是正は、本トークン基盤（Issue #56）を前提として画面別の後続 Issue #57〜#60 が担当する
+- 移行用エイリアス（`--text-h` / `--text` / `--bg` / `--border`）: `App.css` の既存参照が壊れないよう、新トークンの `var()` 別名として `index.css` に残置している。画面別の置き換えが完了した最後の Issue（#60）が撤去する
 
 ## プロジェクト固有ルール
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,19 +1,25 @@
 :root {
-  --text: #6b6375;
-  --text-h: #08060d;
-  --bg: #fff;
-  --border: #e5e4e7;
-  --code-bg: #f4f3ec;
-  --accent: #aa3bff;
-  --accent-bg: rgba(170, 59, 255, 0.1);
-  --accent-border: rgba(170, 59, 255, 0.5);
-  --social-bg: rgba(244, 243, 236, 0.5);
-  --shadow:
-    rgba(0, 0, 0, 0.1) 0 10px 15px -3px, rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
-
-  /* DESIGN.md「Web 版トークン適用方針」（Issue #28）。Android のカラートークン表と値を一致させる */
+  /* DESIGN.md「カラートークン」表（ライト値のみ）。2026-09-08 代表判断により Web はライト固定で
+     ダークモード対応は対象外（Issue #56）。値は DESIGN.md を正本として転記する */
   --color-primary: #00696C;
+  --color-background: #FAFDFC;
+  --color-surface: #FFFFFF;
+  --color-text-primary: #191C1C;
+  --color-text-secondary: #3F4948;
   --color-error: #BA1A1A;
+  --color-warning: #B8860B;
+  --color-success: #2E7D32;
+  --color-favorite: #D32F2F;
+  --color-outline: #e5e4e7;
+
+  --code-bg: #f4f3ec;
+
+  /* 移行用エイリアス（Issue #56）。web/src/App.css から旧トークン名で計47箇所参照されているため、
+     新トークンの別名として定義を残す。撤去は画面別置き換えが完了した最後の Issue（#60）が担当する */
+  --text-h: var(--color-text-primary);
+  --text: var(--color-text-secondary);
+  --bg: var(--color-background);
+  --border: var(--color-outline);
 
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
@@ -21,7 +27,7 @@
 
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
-  color-scheme: light dark;
+  color-scheme: light;
   color: var(--text);
   background: var(--bg);
   font-synthesis: none;
@@ -31,29 +37,6 @@
 
   @media (max-width: 1024px) {
     font-size: 16px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --text: #9ca3af;
-    --text-h: #f3f4f6;
-    --bg: #16171d;
-    --border: #2e303a;
-    --code-bg: #1f2028;
-    --accent: #c084fc;
-    --accent-bg: rgba(192, 132, 252, 0.15);
-    --accent-border: rgba(192, 132, 252, 0.5);
-    --social-bg: rgba(47, 48, 58, 0.5);
-    --shadow:
-      rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
-
-    --color-primary: #4DD8DC;
-    --color-error: #FFB4AB;
-  }
-
-  #social .button-icon {
-    filter: invert(1) brightness(2);
   }
 }
 


### PR DESCRIPTION
Closes #56

## 概要

`web/src/index.css` と `DESIGN.md` を整備し、Web を DESIGN.md のカラートークン表と一致させたうえでライト固定にする。後続の画面別 Issue（#57 共通シャーシ / #58 ログイン画面 / #59 記録一覧 / #60 記録詳細・入力フォーム）が参照できるトークン基盤を作る。**`web/src/App.css` の色置き換えは本 Issue のスコープ外であり、変更していない。**

## 実装内容

1. **Web をライト固定にする**
   - `:root` の `color-scheme` を `light dark` → `light` に変更
   - `@media (prefers-color-scheme: dark)` ブロックを丸ごと撤去（`--color-primary: #4DD8DC` / `--color-error: #FFB4AB` 等のダーク値、`--text` / `--text-h` / `--bg` / `--border` / `--code-bg` / `--accent` 系のダーク値を含む）
   - 同ブロック内の `#social .button-icon { filter: invert(1) brightness(2); }` も撤去（対応する `social` 要素はリポジトリ内に存在しない死んだセレクタ）
2. **未使用のテンプレート由来トークンを削除**
   - `--accent` / `--accent-bg` / `--accent-border` / `--social-bg` / `--shadow` の5つ。着手前に `git grep` で使用箇所0件を再確認済み
3. **DESIGN.md のカラートークンをライト値のみ `index.css` に追加**
   - `--color-background: #FAFDFC` / `--color-surface: #FFFFFF` / `--color-text-primary: #191C1C` / `--color-text-secondary: #3F4948` / `--color-warning: #B8860B` / `--color-success: #2E7D32` / `--color-favorite: #D32F2F`
   - 値は `DESIGN.md` のカラートークン表から転記（`primary` / `error` は既存定義のまま）
4. **`--color-outline`（枠線）を新規トークンとして追加**
   - `DESIGN.md` のカラートークン表に1行追記し、`index.css` に `--color-outline: #e5e4e7` を定義
   - **値の根拠**: 現行の `--border: #e5e4e7` をそのまま採用。背景が `#fff` → `#FAFDFC` に変わるが、両者の差はごく僅か（RGBで最大5/255）で、相対輝度から算出した `#e5e4e7` とのコントラスト比は旧背景で約1.27:1、新背景で約1.24:1とほぼ同一。実ブラウザ（Vite dev server, ログイン画面）で目視確認し、新背景に対しても現行同様にカードの枠線として視認できることを確認した（下記「テスト結果」参照）
5. **旧トークンをエイリアス化**（本 Issue の設計上もっとも重要な点）
   - `--text-h` / `--text` / `--bg` / `--border` を新トークンの `var()` 参照に変更し、**定義自体は削除せず残した**
   - `--text-h: var(--color-text-primary)` / `--text: var(--color-text-secondary)` / `--bg: var(--color-background)` / `--border: var(--color-outline)`
   - コメントで「移行用エイリアスであり、撤去は画面別置き換え完了後の #60 が担当する」旨を明記
   - `--code-bg`（`#f4f3ec`、`index.css` 内の `code { background: var(--code-bg); }` で1箇所使用）は、DESIGN.md に対応する概念（コードスニペット背景）がなく、かつ現状アプリ内に `<code>` 要素の使用箇所がない（Vite テンプレート由来の未使用ルール）ため、指示どおりそのまま存置した
6. **DESIGN.md を更新**
   - 8行目の注記を更新: 調査の結果 `ItemMasters` と経年グラフは既にトークン化済みで直書き0件だったため、その旨を反映し、残る3画面の是正を後続 Issue #57〜#60 に委ねる形に書き換えた
   - 「Web 版トークン適用方針」に **Web はライト固定・ダークモードは対象外**（2026-09-08 代表判断）を明記し、Android はダーク対応を維持するため生じる差異が意図した判断であることを記載
   - 追加トークン（`outline`）をカラートークン表と「Web 版トークン適用方針」の一覧表の両方に追記

## `App.css` について

`git diff origin/main --stat` で `web/src/App.css` が差分に含まれていないことを確認済み（変更なし）。

```
 DESIGN.md         | 32 +++++++++++++++++++++----------
 web/src/index.css | 57 +++++++++++++++++++------------------------------------
 2 files changed, 42 insertions(+), 47 deletions(-)
```

## 表示色が変わる箇所（意図した是正であり退行ではない）

エイリアス化により `App.css` 内の `var(--text)` / `var(--text-h)` / `var(--bg)` / `var(--border)` の解決値が以下のとおり変わる（`App.css` 自体は無変更、`index.css` 側の値変更による影響）。

| 旧トークン | 旧値 | 新値（実質の解決先） | 影響範囲 |
|---|---|---|---|
| `--text`（13箇所） | `#6b6375`（紫がかったグレー） | `#3F4948`（DESIGN.md text-secondary） | 補助テキスト・モーダル本文・記録の施設名/メタ情報・テーブルの参照値など |
| `--text-h`（12箇所） | `#08060d` | `#191C1C`（DESIGN.md text-primary） | 見出し・記録日・フォームラベル・テーブル見出しなど |
| `--bg`（8箇所） | `#fff` | `#FAFDFC`（DESIGN.md background） | カード・モーダル・入力欄の背景 |
| `--border`（15箇所） | `#e5e4e7` | `#e5e4e7`（`--color-outline`。値は変更なし） | カード枠線・テーブル罫線・区切り線 |

`--text` / `--text-h` / `--bg` は肉眼でほぼ判別できない程度の微差（グレー・オフホワイトの色味調整）で、レイアウトや可読性への影響はない。`--border` は値そのものを変更していないため表示上の変化はない。

## テスト結果

- `npm --prefix web run lint`: 成功（既存の未関連warning 1件のみ。`ItemMasters.tsx` の `react-hooks/exhaustive-deps`、本変更と無関係）
- `npm --prefix web run test`: 成功（3ファイル / 29テスト全て pass）
- `npm --prefix web run build`: 成功
- 実ブラウザでの確認: WSL上で `npm --prefix web run dev` を起動し、Claude Code の Browser pane（Chromium）でログイン画面を表示して確認した
  - 通常時（ライト）: 想定どおりの配色で表示
  - ブラウザの `prefers-color-scheme` を `dark` に強制した状態で再読み込みしても、`color-scheme: light` によりライト配色のまま一貫して表示されることを確認（`getComputedStyle` で `--color-background: #FAFDFC` / `--border: #e5e4e7` / `--text: #3F4948` / `--text-h: #191C1C` が解決されることも確認）
  - **未確認事項**: 実機（Windows/Mac/モバイル）の実ブラウザ・実OSダークモード設定での確認はしていない。上記はいずれも Chromium のカラースキームエミュレーション機能による確認であり、実OS環境での見え方は未確認

## 確認事項

- [x] `web/src/App.css` の差分が0であること
- [x] エイリアス化により `App.css` の既存参照が壊れていないこと（lint/test/build 通過、Browser pane でログイン画面の表示崩れがないことを確認）
- [x] `npm --prefix web run lint` / `test` / `build` が全て通ること
- [x] エイリアス化による表示色変更箇所の一覧化
- [x] OS ダークモード下でのライト配色一貫表示（Chromium のエミュレーションで確認。実OSでの確認は未実施）
