### PR TITLE
fix(test): main のコンパイルエラーを修復する（FakeHealthCloudSync に deleteRecord の override を追加）

### DIFF
--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryMirrorDeleteTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryMirrorDeleteTest.kt
@@ -241,5 +241,9 @@ class HealthRepositoryMirrorDeleteTest {
         override suspend fun deleteAllUserData(uid: String) {
             // Issue #46 のミラー削除テストの対象外（Issue #34 のアカウント削除専用メソッド）
         }
+
+        override suspend fun deleteRecord(uid: String, recordId: Long) {
+            // Issue #46 のミラー削除テストの対象外（Issue #47 の記録1件削除専用メソッド）
+        }
     }
 }


### PR DESCRIPTION
## 概要

**現在の `main` がコンパイルできず、Android の `unit-test` ジョブが失敗し続けています。** その修正です。

```
e: HealthRepositoryMirrorDeleteTest.kt:216:13 Class 'FakeHealthCloudSync' is not abstract and
does not implement abstract member public abstract suspend fun deleteRecord(uid: String, recordId: Long): Unit
defined in com.rokusoudo.healthcheckup.data.repository.HealthCloudSync
```

`HealthRepositoryMirrorDeleteTest` の `FakeHealthCloudSync` に、空実装の `deleteRecord` override を1つ追加します。

## 原因: テキスト上は競合しない「意味的なコンフリクト」

PR #54（Issue #46）と PR #55（Issue #47）が本日相次いでマージされたことで発生しました。**どちらの PR も単体では CI が green で、git もコンフリクトを報告しませんでした。**

| | 追加したもの | 影響 |
|---|---|---|
| PR #55 | `HealthCloudSync` インターフェースに `deleteRecord(uid, recordId)` | 全 fake 実装に override が必要になった |
| PR #54 | `HealthRepositoryMirrorDeleteTest`（新規ファイル・独自の `FakeHealthCloudSync`） | PR #55 の存在を知らないため `deleteRecord` を実装していない |

両者は**別のファイル**を変更しているため git は自動マージし、コンフリクトも出しませんでした。しかしマージ後の組み合わせではインターフェースの実装が欠け、コンパイルが通りません。

コンフリクト解消時、PR #55 側では既存の fake 5つに override を追加しましたが、`HealthRepositoryMirrorDeleteTest` は当時 PR #54 のブランチにしか存在せず、PR #55 のブランチからは見えませんでした。逆に PR #54 側は、当時 `deleteRecord` がまだ `main` になかったため対応しようがありませんでした。

## 変更内容

`HealthRepositoryMirrorDeleteTest.kt` の `FakeHealthCloudSync` に `deleteRecord` の空実装を追加。既存の `deleteAllUserData` の空実装と同じ流儀に揃え、なぜ空なのかをコメントで示しています。

本 PR は**コンパイルを通すための最小限の修正**であり、テストロジック・プロダクションコードは一切変更していません。

## 他に同じ欠落がないことの確認

`HealthCloudSync` を実装している test 配下の6ファイルすべてを確認し、`deleteRecord` と `deleteAllUserData` の override 有無を突き合わせました。**欠けていたのは本 PR で修正した1ファイルのみ**です。

| ファイル | deleteRecord | deleteAllUserData |
|---|---|---|
| AccountDeletionManagerTest | ✅ | ✅ |
| HealthRepositoryDeleteTest | ✅ | ✅ |
| **HealthRepositoryMirrorDeleteTest** | **❌ → 本 PR で追加** | ✅ |
| HealthRepositoryRecalcTest | ✅ | ✅ |
| HealthRepositorySignOutTest | ✅ | ✅ |
| HealthRepositoryStartupResyncTest | ✅ | ✅ |

## テスト

`./gradlew test`（debug / release 両方）が **BUILD SUCCESSFUL**。

## 再発防止についての所見（本 PR のスコープ外・報告のみ）

今回のような「共有インターフェースにメソッドを足す PR」が複数並走すると、個々の CI が green でもマージ後に壊れます。git のテキストマージでは検出できません。

対策の候補としては、CI に `merge_group`（マージキュー）を導入してマージ後の状態で検証する、あるいは fake 実装を各テストファイルに複製せず共有のテストダブルに集約する、といった方法があります。必要であれば別 Issue として起票します。
