### PR TITLE
docs: CI とブランチ保護の方針を記録する（Refs #63）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,3 +329,53 @@ users/{uid}/
 - [ ] CameraX + ML Kit の動作確認プロトタイプ（撮影→テキスト抽出表示）
 
 > 完全なDB保存・グラフ機能は Phase 2 以降。
+
+---
+
+## 8. CI とブランチ保護の方針
+
+`main` は ruleset `main-protection` で保護する。設定内容と、なぜその設定にしているかを以下に記録する。
+
+### 必須ステータスチェック
+
+| チェック | ワークフロー | 対象 |
+|---------|-------------|------|
+| `unit-test` | `android-test.yml` | Android のユニットテスト・ビルド |
+| `rules-test` | `firestore-rules-test.yml` | Firestore セキュリティルール（Emulator） |
+| `lint-and-build` | `web-ci.yml` | Web の Lint・テスト・ビルド |
+
+Android・Firestore ルール・Web のいずれが壊れても `main` に入らないよう、3つとも必須にする。
+
+### Require branches to be up to date before merging（strict）
+
+**この設定は有効にする。無効に戻さないこと。**
+
+ruleset の `strict_required_status_checks_policy` を `true` にすると、base（`main`）が進んだ PR は
+ブランチを更新して CI を再実行するまでマージできなくなる。マージのたびに他の open PR で
+再実行が必要になるが、次の理由でその手間を受け入れる。
+
+**根拠となった事故（2026-09-08）**
+
+`main` がコンパイルできない状態になった。原因は、テキスト上は競合しないが組み合わせると壊れる
+「意味的なコンフリクト」である。
+
+1. PR #55（Issue #47）が `HealthCloudSync` インターフェースに `deleteRecord` を追加した
+2. PR #54（Issue #46）が新規テストファイル（独自の `FakeHealthCloudSync`）を追加した。
+   PR #55 の存在を知らないため `deleteRecord` を実装していない
+3. **両 PR とも CI は green。git も競合を報告しない**（変更ファイルが異なるため）。そのままマージ
+4. マージ後の `main` でコンパイルエラー。以降すべての PR の `unit-test` が赤くなった
+
+どちらの PR にも欠陥はない。それぞれ「自分が CI を回した時点の `main`」では正しかった。
+`pull_request` イベントの CI は PR と base のマージ結果に対して走るため本来は検出できたはずで、
+検出できなかったのは **CI 実行後に `main` が動いたのに再実行が強制されなかった**ためである。
+strict を有効にすれば、この破損はマージ前に検出される。
+
+同じ設定は逆方向の事故も防ぐ。修復 PR のマージ後、既存 PR の CI が再実行されず
+「古い赤」が残り続ける現象も同日に発生した（Issue #56 / PR #61）。
+
+なお**マージキュー（`merge_group`）は採用しない**。本リポジトリは public のため機能自体は
+利用できるが、上記の事例は strict で防げる。PR が並走して滞留するようになった時点で再検討する。
+
+### 関連
+
+- 追従漏れが起きにくい構造にする側の対策（`FakeHealthCloudSync` の複製解消）は Issue #64 で扱う


### PR DESCRIPTION
## 概要

Issue #63 の受け入れ基準のうち、**ドキュメント側**を担当します。`docs/architecture.md` に「8. CI とブランチ保護の方針」を新設し、必須ステータスチェックの一覧と、strict 設定を有効にする根拠（2026-09-08 の `main` 破損）を記録しました。

Refs #63

## この PR に含まれないもの

**ruleset の設定変更そのものは含みません。** リポジトリ設定の操作であり、後述のとおり API 経由では実行できなかったため、代表の Web UI 操作が必要です。Issue #63 は設定変更が完了するまで close しないでください。

## ruleset を API で変更できなかった件（調査結果）

`gh` の OAuth トークン（`gho_`・scopes: `gist, project, read:org, repo, workflow`）では、ruleset の
**読み取りはできるが書き込みができません**。

```
GET  /repos/rokusoudo-product/health-checkup-manager/rulesets/20241139   → 200 OK
PATCH /repos/rokusoudo-product/health-checkup-manager/rulesets/20241139  → 404 Not Found
```

- リポジトリ権限は `admin: true` であり、権限不足ではありません
- ペイロードを最小（`name` のみ）にしても 404 になるため、payload の問題でもありません
- GitHub は権限のないリソースへの書き込みに対し、存在を秘匿するため 403 ではなく 404 を返します

同じ調査を繰り返さないよう、結果をここに残します。

## 代表にお願いする操作

Settings → Rules → **main-protection** を開き、次の2点を変更してください。

1. **Require branches to be up to date before merging** を **ON** にする
2. Require status checks to pass の一覧に **`lint-and-build`** を追加する（現在は `unit-test` と `rules-test` の2つのみ）

直接リンク: https://github.com/rokusoudo-product/health-checkup-manager/rules/20241139

変更後の想定される状態（確認用）:

```json
"required_status_checks": {
  "strict_required_status_checks_policy": true,
  "required_status_checks": [
    { "context": "unit-test" },
    { "context": "rules-test" },
    { "context": "lint-and-build" }
  ]
}
```

## 変更内容

`docs/architecture.md` に節を1つ追加しただけで、コードの変更はありません。

- 必須ステータスチェック3つの一覧（どのワークフローが何を守るか）
- strict を有効にする根拠として、2026-09-08 の事故の経緯を4ステップで記録
- 「どちらの PR にも欠陥はない」ことを明記（将来この記録を読んだ人が、PR の書き方の問題だと誤解しないようにするため）
- 「無効に戻さないこと」と明記（運用の手間が増えるため、理由を知らない人が外しにくいようにする）
- マージキューを採用しない判断と、その再検討条件

## テスト

ドキュメントのみの変更のため、コードへの影響はありません。CI は通常どおり実行されます。
