### PR TITLE
Web共通シャーシ（ナビゲーション・共通ボタン）をカラートークンへ移行 (#57)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,6 +24,10 @@
 | success | #2E7D32 | #81C784 | 成功 |
 | favorite | #D32F2F | #EF5350 | お気に入り♥（ON時） |
 | outline | #e5e4e7 | 未定義 | 枠線（2026-09-08 追記, Issue #56。Web の `--border` 用に新設。現行 Web の値 `#e5e4e7` をそのまま採用し、背景 `#FAFDFC` に対して枠線として視認できることを確認した。Android では未使用のためダーク値は未定義） |
+| on-primary | #FFFFFF | 未定義 | primary 背景上の文字色（2026-09-09 追記, Issue #57。Web専用。Android colors.xml の既存 `on_primary`（#FFFFFFFF）と同値のため、Android 側の新規追記は不要と判断。ダークは Web 対象外のため未定義） |
+| primary-hover | #00595C | 未定義 | primary 系コントロールの hover/pressed 背景（2026-09-09 追記, Issue #57。Web専用。確定 primary `#00696C` を基準に、`color-mix(in srgb, var(--color-primary) 85%, black)` 相当（primary 85% + 黒 15%）で算出。旧 Web 実装の `#155f55` は旧 primary `#1a7a6e` から導出された値のため系統が異なり、そのまま採用していない。ダークは Web 対象外のため未定義） |
+| disabled | #aaaaaa | 未定義 | 無効状態の背景・主張を抑えたアイコン文字色（2026-09-09 追記, Issue #57。Web専用。現行 Web の値 `#aaa` をそのまま採用。WCAG 1.4.3 は無効化されたUIコンポーネントを対象外としているためコントラスト要件の対象外。ダークは Web 対象外のため未定義） |
+| hover-neutral | #f5f5f5 | 未定義 | ニュートラル系ボタン（`.btn-secondary` 等）の hover 背景（2026-09-09 追記, Issue #57。Web専用。現行 Web の値 `#f5f5f5` をそのまま採用。ダークは Web 対象外のため未定義） |
 
 ### カテゴリカラー（検査項目の文字・枠色。2026-07-18 決定 Q1）
 
@@ -77,7 +81,7 @@ Web（`web/`）で新規に追加する画面は、Android と同じ意味のト
   Android は `res/values/colors.xml` / `res/values-night/colors.xml` の2本立てでダークモードに対応しているため、**Android はダーク対応・Web はライト固定**という差異が生じる。これは意図した判断であり、Web のダーク対応漏れではない。
 - 定義場所: `web/src/index.css` の `:root`（ライト値のみ）
 - 命名: `--color-<トークン名>`（Android のトークン表と同じ名前を使う）
-- 現時点で定義済みのトークン（ライト値のみ。Issue #56 で `primary` / `error` 以外を追加）:
+- 現時点で定義済みのトークン（ライト値のみ。Issue #56 で `primary` / `error` 以外を追加。Issue #57 で `on-primary` / `primary-hover` / `disabled` / `hover-neutral` を追加）:
 
 | CSS変数 | トークン | ライト | 用途 |
 |--------|---------|-------|------|
@@ -91,6 +95,10 @@ Web（`web/`）で新規に追加する画面は、Android と同じ意味のト
 | `--color-success` | success | #2E7D32 | 成功 |
 | `--color-favorite` | favorite | #D32F2F | お気に入り♥（ON時） |
 | `--color-outline` | outline | #e5e4e7 | 枠線 |
+| `--color-on-primary` | on-primary | #FFFFFF | navbar・`.btn-primary`・`.btn-logout` など primary 背景上の文字色（2026-09-09 追記, Issue #57） |
+| `--color-primary-hover` | primary-hover | #00595C | `.btn-primary:hover` の背景（2026-09-09 追記, Issue #57） |
+| `--color-disabled` | disabled | #aaaaaa | `.btn-primary:disabled` の背景 / `.btn-remove` の既定文字色（2026-09-09 追記, Issue #57） |
+| `--color-hover-neutral` | hover-neutral | #f5f5f5 | `.btn-secondary:hover` の背景（2026-09-09 追記, Issue #57） |
 
 - 通常の CSS（`color` / `background` 等）では `var(--color-primary)` のようにそのまま参照する
 - **Canvas 描画（Chart.js 等）では `var()` がブラウザの Canvas 2D API 上で解決されないため**、`getComputedStyle(document.documentElement).getPropertyValue('--color-primary')` で実測値の文字列を取得してから渡す（`web/src/components/TrendChart.tsx` 参照）

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -12,8 +12,8 @@
   gap: 24px;
   padding: 0 24px;
   height: 56px;
-  background: #1a7a6e;
-  color: #fff;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -22,7 +22,7 @@
 .nav-brand {
   font-weight: 700;
   font-size: 18px;
-  color: #fff;
+  color: var(--color-on-primary);
   text-decoration: none;
   white-space: nowrap;
 }
@@ -43,7 +43,7 @@
 }
 .nav-link:hover, .nav-link.active {
   background: rgba(255,255,255,0.15);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .nav-user {
@@ -67,7 +67,7 @@
 
 .btn-logout {
   background: rgba(255,255,255,0.15);
-  color: #fff;
+  color: var(--color-on-primary);
   border: none;
   border-radius: 6px;
   padding: 6px 12px;
@@ -211,8 +211,8 @@ h1 {
 /* ── 共通ボタン ──────────────────────────────────────── */
 
 .btn-primary {
-  background: #1a7a6e;
-  color: #fff;
+  background: var(--color-primary);
+  color: var(--color-on-primary);
   border: none;
   border-radius: 8px;
   padding: 10px 20px;
@@ -223,23 +223,23 @@ h1 {
   text-decoration: none;
   display: inline-block;
 }
-.btn-primary:hover { background: #155f55; }
-.btn-primary:disabled { background: #aaa; cursor: not-allowed; }
+.btn-primary:hover { background: var(--color-primary-hover); }
+.btn-primary:disabled { background: var(--color-disabled); cursor: not-allowed; }
 
 .btn-secondary {
   background: transparent;
-  color: var(--text);
-  border: 1px solid var(--border);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-outline);
   border-radius: 8px;
   padding: 10px 20px;
   font-size: 14px;
   cursor: pointer;
   transition: background 0.2s;
 }
-.btn-secondary:hover { background: #f5f5f5; }
+.btn-secondary:hover { background: var(--color-hover-neutral); }
 
 .btn-back {
-  color: #1a7a6e;
+  color: var(--color-primary);
   text-decoration: none;
   font-size: 14px;
 }
@@ -247,47 +247,47 @@ h1 {
 
 .btn-danger {
   background: transparent;
-  color: #d32f2f;
-  border: 1px solid #d32f2f;
+  color: var(--color-error);
+  border: 1px solid var(--color-error);
   border-radius: 8px;
   padding: 8px 16px;
   font-size: 13px;
   cursor: pointer;
 }
-.btn-danger:hover { background: #ffeaea; }
+.btn-danger:hover { background: color-mix(in srgb, var(--color-error) 12%, transparent); }
 
 .btn-text {
   background: none;
   border: none;
-  color: #1a7a6e;
+  color: var(--color-primary);
   cursor: pointer;
   font-size: 13px;
   padding: 4px 8px;
 }
-.btn-text.danger { color: #d32f2f; }
+.btn-text.danger { color: var(--color-error); }
 .btn-text:hover { text-decoration: underline; }
 
 .btn-add-item {
   background: transparent;
-  color: #1a7a6e;
-  border: 1px dashed #1a7a6e;
+  color: var(--color-primary);
+  border: 1px dashed var(--color-primary);
   border-radius: 6px;
   padding: 6px 14px;
   font-size: 13px;
   cursor: pointer;
 }
-.btn-add-item:hover { background: #f0faf9; }
+.btn-add-item:hover { background: color-mix(in srgb, var(--color-primary) 8%, transparent); }
 
 .btn-remove {
   background: none;
   border: none;
-  color: #aaa;
+  color: var(--color-disabled);
   cursor: pointer;
   font-size: 16px;
   padding: 4px 8px;
   flex-shrink: 0;
 }
-.btn-remove:hover { color: #d32f2f; }
+.btn-remove:hover { color: var(--color-error); }
 .btn-remove:disabled { opacity: 0.3; cursor: not-allowed; }
 
 /* ── 記録一覧 ────────────────────────────────────────── */
@@ -557,11 +557,11 @@ h2 {
 
 /* ── 共通 ──────────────────────────────────────────── */
 
-.msg { color: var(--text); font-size: 15px; padding: 20px 0; }
+.msg { color: var(--color-text-secondary); font-size: 15px; padding: 20px 0; }
 .error {
-  color: #d32f2f;
+  color: var(--color-error);
   font-size: 13px;
-  background: #ffeaea;
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
   border-radius: 6px;
   padding: 8px 12px;
   margin: 0;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -12,6 +12,13 @@
   --color-favorite: #D32F2F;
   --color-outline: #e5e4e7;
 
+  /* 以下4トークンは Issue #57（共通シャーシのトークン化）で追加。DESIGN.md のカラートークン表にも追記済み。
+     Android は本 Issue のスコープ外のため未対応（on-primary のみ Android colors.xml の on_primary と同値） */
+  --color-on-primary: #FFFFFF;
+  --color-primary-hover: #00595C;
+  --color-disabled: #aaaaaa;
+  --color-hover-neutral: #f5f5f5;
+
   --code-bg: #f4f3ec;
 
   /* 移行用エイリアス（Issue #56）。web/src/App.css から旧トークン名で計47箇所参照されているため、


### PR DESCRIPTION
Closes #57

## 概要

Issue #56 で整備したトークン基盤（`web/src/index.css`）を踏まえ、Web版の共通シャーシ（ナビゲーション・共通ボタン・末尾の共通スタイル）における `web/src/App.css` のカラーコード直書きをトークン参照へ移行しました。ダーク値の追加は行っていません（代表判断によりWebはライト固定）。

## 変更ファイル（3つ）

- `web/src/App.css`（担当3セクションのみ。他セクションは未変更）
- `web/src/index.css`（新規トークン4つの追加）
- `DESIGN.md`（新規トークンの表への追記）

## 対象範囲（App.css）と差分の閉じ込み確認

| セクション | 行範囲 |
|---|---|
| `/* ── レイアウト ── */` | 1〜92 |
| `/* ── 共通ボタン ── */` | 211〜292 |
| `/* ── 共通 ── */`（末尾） | 558〜570 |

`git diff -U0 web/src/App.css` の全ハンクが上記3範囲内に収まっていることを確認済みです（担当外セクションへの変更なし）。

```
@@ -15,2 +15,2 @@ / @@ -25 +25 @@ / @@ -46 +46 @@ / @@ -70 +70 @@
@@ -214,2 / -226,2 / -231,2 / -239 / -242 / -250,2 / -257 / -262 / -267 / -272,2 / -279 / -284 / -290
@@ -560 / -562 / -564
```

## 機械的な置き換え（primary / error トークン）

- `#1a7a6e` → `var(--color-primary)`（`#00696C`）: navbar 背景、`.btn-primary` 背景、`.btn-back` / `.btn-text` / `.btn-add-item` の文字色・枠線
- `#d32f2f` → `var(--color-error)`（`#BA1A1A`）: `.btn-danger` 文字色・枠線、`.btn-text.danger`、`.btn-remove:hover`、`.error` 文字色

## 新規トークン（DESIGN.md に根拠を追記）

`DESIGN.md` に対応トークンがなかった4色は、以下の新規トークンとして `index.css` に定義し、DESIGN.md の「カラートークン」表（Android/共通側）と「Web 版トークン適用方針」の表の両方に追記しました（Issue #56 で `outline` を追加した際の書き方に倣っています）。

| 新規トークン | 値 | 用途 | 根拠 |
|---|---|---|---|
| `--color-on-primary` | `#FFFFFF` | primary 背景上の文字色（navbar・`.btn-primary`・`.btn-logout` 等） | `--color-surface`（カード・パネル背景の意味）を代用せず、Material Design 3 の慣例に倣い新設。Android の `colors.xml` に既存の `on_primary`（`#FFFFFFFF`）と同値であり、意味・値ともに整合している |
| `--color-primary-hover` | `#00595C` | `.btn-primary:hover` の背景 | 確定 primary `#00696C` を基準に、`color-mix(in srgb, var(--color-primary) 85%, black)` 相当（primary 85% + 黒 15%）で算出。旧実装の `#155f55` は旧 primary `#1a7a6e` から導出された値で系統が異なるため、そのまま採用していない。Canvas 描画での `getComputedStyle` 実測取得（DESIGN.md既定）に配慮し、トークン自体はリテラル16進値として定義（`color-mix()` 式そのものは持たせていない） |
| `--color-disabled` | `#aaaaaa` | `.btn-primary:disabled` の背景 / `.btn-remove` の既定文字色（主張を抑えた色） | 既存の直書き値 `#aaa` をそのまま新規トークン化。新しい配色は設計していない |
| `--color-hover-neutral` | `#f5f5f5` | `.btn-secondary:hover` の背景 | 既存の直書き値 `#f5f5f5` をそのまま新規トークン化。中立トーンのため primary/outline からの導出は行わなかった |

### トークン化せず `color-mix()` に置き換えたもの（新規トークン不要と判断）

以下2パターン・計3箇所は、既存の `.btn-delete-account:hover { background: color-mix(in srgb, var(--color-error) 12%, transparent); }`（`App.css` 150行、Issue #34 実装）と同一パターンを踏襲し、新しい16進値を定義せず `--color-error` / `--color-primary` からの導出式をそのまま使いました。新規の配色ではなく既存トークンの計算式のため、DESIGN.md への新規トークン追加は行っていません。

- `#ffeaea` → `color-mix(in srgb, var(--color-error) 12%, transparent)`（`.btn-danger:hover` 背景、`.error` 背景の2箇所）
- `#f0faf9` → `color-mix(in srgb, var(--color-primary) 8%, transparent)`（`.btn-add-item:hover` 背景）

## 旧トークン参照の書き換え

担当セクション内にあった旧トークン参照を新トークン名へ書き換えました。

- `.btn-secondary` の `color: var(--text)` → `var(--color-text-secondary)`
- `.btn-secondary` の `border: 1px solid var(--border)` → `var(--color-outline)`
- `.msg` の `color: var(--text)` → `var(--color-text-secondary)`

`index.css` の移行用エイリアス（`--text-h` / `--text` / `--bg` / `--border`）自体は削除していません（他セクションがまだ参照しているため。撤去は #60 の担当）。

## 除外した箇所（rgba() のオーバーレイ・影）

以下は `rgba()` によるオーバーレイ表現で、DESIGN.md のトークン表に対応概念がないため置き換えを見送りました（是正対象は不透明色の直書きであり、これらは透過オーバーレイのため対象外と判断）。

- 37行 `.nav-link { color: rgba(255,255,255,0.8); }`
- 45行 `.nav-link:hover, .nav-link.active { background: rgba(255,255,255,0.15); }`
- 64行 `.nav-name { color: rgba(255,255,255,0.9); }`
- 69行 `.btn-logout { background: rgba(255,255,255,0.15); }`
- 78行 `.btn-logout:hover { background: rgba(255,255,255,0.25); }`
- 83行 `.btn-delete-account-link { color: rgba(255,255,255,0.75); }`

## 表示色が変わる箇所（一覧）

意図した是正であり退行ではないことの確認用です。

| 箇所 | 旧 | 新 | 備考 |
|---|---|---|---|
| navbar 背景、`.btn-primary` 背景 | `#1a7a6e` | `#00696C` | primary トークンへ是正 |
| `.nav-brand` / `.nav-link:hover,.active` / `.btn-logout` の文字色、`.btn-primary` の文字色 | `#fff` | `#FFFFFF`（`--color-on-primary`） | 値は同一。トークン化のみで見た目の変化なし |
| `.btn-back` / `.btn-text` / `.btn-add-item` の文字色・枠線 | `#1a7a6e` | `#00696C` | primary トークンへ是正 |
| `.btn-primary:hover` 背景 | `#155f55` | `#00595C` | 新 primary 基準で算出し直した値へ是正（系統の異なる旧値を踏襲しない） |
| `.btn-primary:disabled` 背景、`.btn-remove` 文字色 | `#aaa` | `#aaaaaa`（`--color-disabled`） | 値は同一。トークン化のみで見た目の変化なし |
| `.btn-secondary:hover` 背景 | `#f5f5f5` | `#f5f5f5`（`--color-hover-neutral`） | 値は同一。トークン化のみで見た目の変化なし |
| `.btn-danger` 文字色・枠線、`.btn-text.danger`、`.btn-remove:hover`、`.error` 文字色 | `#d32f2f` | `#BA1A1A` | error トークンへ是正 |
| `.btn-danger:hover` 背景、`.error` 背景 | `#ffeaea` | `color-mix(in srgb, var(--color-error) 12%, transparent)` ≒ 白背景上で `#F7E4E4` / `#FAFDFC` 背景上で `#F2E2E1` | error トークンから導出。旧値とほぼ同系統の淡いピンクで視認上の違いはごく僅か |
| `.btn-add-item:hover` 背景 | `#f0faf9` | `color-mix(in srgb, var(--color-primary) 8%, transparent)` ≒ 白背景上で `#EBF3F3` / `#FAFDFC` 背景上で `#E6F1F0` | primary トークンから導出。旧値とほぼ同系統の淡いティールで視認上の違いはごく僅か |

## コントラスト確認（WCAG 2.1 AA 4.5:1 以上）

sRGB 相対輝度から算出（`color-mix()` は sRGB 空間での単純加重平均として概算）。

| 組み合わせ | コントラスト比 | 判定 |
|---|---|---|
| 白文字（on-primary） / 新 primary `#00696C`（navbar・`.btn-primary` 背景） | 6.49:1 | AA達成（参考: 旧 `#1a7a6e` は5.18:1でも達成、旧primaryも問題なかった） |
| 白文字（on-primary） / `.btn-primary:hover` `#00595C` | 8.10:1 | AA達成 |
| primary文字 `#00696C` / 白背景（`.btn-back`等） | 6.49:1 | AA達成 |
| primary文字 `#00696C` / 背景色 `#FAFDFC`（`.btn-back`等） | 6.34:1 | AA達成 |
| error文字 `#BA1A1A` / 白背景（`.btn-danger`等） | 6.46:1 | AA達成 |
| error文字 `#BA1A1A` / 背景色 `#FAFDFC`（`.btn-danger`等） | 6.31:1 | AA達成 |
| 白文字（`.btn-primary:disabled` の文字は on-primary を継承） / disabled背景 `#aaaaaa` | 2.32:1 | **AA未達だが、WCAG 1.4.3 は無効化(disabled)されたUIコンポーネントを適用除外としており、要件の対象外。旧実装（`#aaa` 背景 + 白文字）から変更なし・新規の退行ではない** |

いずれも通常状態のボタン・リンクはAA基準を満たしています。disabled状態のみ基準未達ですが、これは是正前から存在する状態であり、かつWCAGの適用除外対象のため据え置いています。

## テスト結果

WSL上で以下をすべて実行し、成功を確認しました。

- `npm --prefix web run lint` → 0 errors, 1 warning（`ItemMasters.tsx` の既存warningで本変更と無関係）
- `npm --prefix web run test` → 3 test files / 29 tests all passed
- `npm --prefix web run build` → ビルド成功（チャンクサイズ警告は既存のもので本変更と無関係）

## 未確認事項

- 実ブラウザでの表示確認は行っていません。上記の表示色変更・コントラスト値は計算上の確認のみです。実際のレンダリング（`color-mix()` のブラウザ挙動含む）はレビュー時に確認をお願いします。

## その他

- `App.css` の担当セクション以外（ログイン画面・記録一覧・記録詳細・入力フォーム）は変更していません（`#1a7a6e`/`#d32f2f` が190, 330, 339, 402行に残存していますが、それぞれ #58/#59/#60 の担当範囲です）
- `index.css` の移行用エイリアス（`--text-h`/`--text`/`--bg`/`--border`）は削除していません（#60 が担当）
- ダーク値の新規定義はしていません
