### PR TITLE
fix(web): 項目マスターの基準値変更時に既存記録のisAbnormalを再計算する

### DIFF
--- a/web/src/firestoreService.ts
+++ b/web/src/firestoreService.ts
@@ -6,12 +6,16 @@ import {
 import type { CollectionReference, DocumentData } from 'firebase/firestore'
 import { db } from './firebase'
 import type { ExaminationRecord, ItemMaster } from './types'
+import { recalcRecordsForMaster, referenceRangeChanged } from './lib/recalcAbnormal'
 
 const recordsRef = (uid: string) =>
   collection(db, 'users', uid, 'records')
 
 const mastersRef = (uid: string) =>
   collection(db, 'users', uid, 'itemMasters')
+
+// WriteBatch は1回あたり最大500件までしか操作できないため、500件ごとに分割してコミットする。
+const FIRESTORE_BATCH_LIMIT = 500
 
 // ── 診断記録 ────────────────────────────────────────────
 
@@ -51,9 +55,41 @@ export async function fetchMasters(uid: string): Promise<ItemMaster[]> {
   return snap.docs.map(d => ({ itemName: d.id, ...d.data() } as ItemMaster))
 }
 
+/**
+ * 項目マスターを保存する。
+ * 基準値（referenceMin / referenceMax）が実際に変化した場合のみ、
+ * Android の HealthRepository.upsertMaster()（Issue #8 / PR #11）と同じ判定で
+ * 該当項目名を含む既存記録を再計算し、Firestore 上の
+ * items[].referenceMin / referenceMax / isAbnormal を更新する
+ * （カテゴリ変更・お気に入りトグルのみでは記録を更新しない＝不要な全件書き込みを避ける）。
+ *
+ * Issue #50 の前提: 再計算は Web クライアント側で全記録を取得して走査する方式
+ * （Cloud Functions への移行は行わない）。判定ロジック自体は ./lib/recalcAbnormal.ts に
+ * 純関数として切り出してあるため、将来 Cloud Functions 側に寄せる場合もそのまま流用できる。
+ */
 export async function saveMaster(uid: string, master: ItemMaster): Promise<void> {
   const { itemName, ...rest } = master
-  await setDoc(doc(db, 'users', uid, 'itemMasters', itemName), rest)
+  const masterRef = doc(db, 'users', uid, 'itemMasters', itemName)
+  const previousSnap = await getDoc(masterRef)
+  const previous = previousSnap.exists()
+    ? (previousSnap.data() as Pick<ItemMaster, 'referenceMin' | 'referenceMax'>)
+    : null
+
+  await setDoc(masterRef, rest)
+
+  if (!referenceRangeChanged(previous, master)) return
+
+  const records = await fetchRecords(uid)
+  const updates = recalcRecordsForMaster(records, itemName, master.referenceMin, master.referenceMax)
+  if (updates.length === 0) return
+
+  for (let i = 0; i < updates.length; i += FIRESTORE_BATCH_LIMIT) {
+    const batch = writeBatch(db)
+    for (const update of updates.slice(i, i + FIRESTORE_BATCH_LIMIT)) {
+      batch.update(doc(db, 'users', uid, 'records', update.recordId), { items: update.items })
+    }
+    await batch.commit()
+  }
 }
 
 export async function deleteMaster(uid: string, itemName: string): Promise<void> {
@@ -61,8 +97,6 @@ export async function deleteMaster(uid: string, itemName: string): Promise<void>
 }
 
 // ── アカウント削除（Issue #34） ────────────────────────────
-
-const FIRESTORE_BATCH_LIMIT = 500
 
 /**
  * コレクション内の全ドキュメントを削除する。

--- a/web/src/lib/recalcAbnormal.test.ts
+++ b/web/src/lib/recalcAbnormal.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateAbnormal,
+  recalcRecordsForMaster,
+  referenceRangeChanged,
+  toDoubleOrNull,
+} from './recalcAbnormal'
+import type { ExaminationRecord } from '../types'
+
+function record(
+  id: string,
+  items: Array<{
+    itemName: string
+    value: string
+    unit?: string
+    referenceMin?: number | null
+    referenceMax?: number | null
+    isAbnormal?: boolean
+  }>,
+): ExaminationRecord {
+  return {
+    id,
+    date: '2026-01-01',
+    facility: '',
+    createdAt: 0,
+    items: items.map(i => ({
+      itemName: i.itemName,
+      value: i.value,
+      unit: i.unit ?? '',
+      referenceMin: i.referenceMin ?? null,
+      referenceMax: i.referenceMax ?? null,
+      isAbnormal: i.isAbnormal ?? false,
+    })),
+  }
+}
+
+describe('toDoubleOrNull', () => {
+  it('数値文字列を数値化する', () => {
+    expect(toDoubleOrNull('22.5')).toBe(22.5)
+    expect(toDoubleOrNull('-3.2')).toBe(-3.2)
+  })
+
+  it('前後の空白は無視する', () => {
+    expect(toDoubleOrNull(' 120 ')).toBe(120)
+  })
+
+  it('数値化できない文字列は null を返す（陰性など）', () => {
+    expect(toDoubleOrNull('陰性')).toBeNull()
+  })
+
+  it('空文字は null を返す', () => {
+    expect(toDoubleOrNull('')).toBeNull()
+  })
+
+  it('部分的にしか数値でない文字列は null を返す（parseFloat とは異なる挙動）', () => {
+    expect(toDoubleOrNull('12kg')).toBeNull()
+  })
+})
+
+describe('evaluateAbnormal（Android HealthRepository.evaluateAbnormal と同じ結果になること）', () => {
+  it('下限未満は true', () => {
+    expect(evaluateAbnormal('60', 70, 139)).toBe(true)
+  })
+
+  it('上限超過は true', () => {
+    expect(evaluateAbnormal('160', 70, 139)).toBe(true)
+  })
+
+  it('範囲内は false', () => {
+    expect(evaluateAbnormal('100', 70, 139)).toBe(false)
+  })
+
+  it('境界値（下限・上限そのもの）は範囲内として false', () => {
+    expect(evaluateAbnormal('70', 70, 139)).toBe(false)
+    expect(evaluateAbnormal('139', 70, 139)).toBe(false)
+  })
+
+  it('数値でない値は false', () => {
+    expect(evaluateAbnormal('陰性', 70, 139)).toBe(false)
+  })
+
+  it('基準値が両方 null の場合は常に false', () => {
+    expect(evaluateAbnormal('999', null, null)).toBe(false)
+  })
+
+  it('下限のみ設定されている場合、上限チェックは行わない', () => {
+    expect(evaluateAbnormal('99999', 70, null)).toBe(false)
+    expect(evaluateAbnormal('1', 70, null)).toBe(true)
+  })
+
+  it('上限のみ設定されている場合、下限チェックは行わない', () => {
+    expect(evaluateAbnormal('-99999', null, 139)).toBe(false)
+    expect(evaluateAbnormal('999', null, 139)).toBe(true)
+  })
+})
+
+describe('referenceRangeChanged（Android HealthRepository.referenceRangeChanged と同じ結果になること）', () => {
+  it('referenceMin が変化した場合は true', () => {
+    const previous = { referenceMin: 70, referenceMax: 139 }
+    const updated = { referenceMin: 80, referenceMax: 139 }
+    expect(referenceRangeChanged(previous, updated)).toBe(true)
+  })
+
+  it('referenceMax が変化した場合は true', () => {
+    const previous = { referenceMin: 70, referenceMax: 139 }
+    const updated = { referenceMin: 70, referenceMax: 150 }
+    expect(referenceRangeChanged(previous, updated)).toBe(true)
+  })
+
+  it('基準値が変化していない場合は false（単位のみ変更など）', () => {
+    const previous = { referenceMin: 70, referenceMax: 139 }
+    const updated = { referenceMin: 70, referenceMax: 139 }
+    expect(referenceRangeChanged(previous, updated)).toBe(false)
+  })
+
+  it('previous が null（新規登録）で基準値が設定される場合は true', () => {
+    expect(referenceRangeChanged(null, { referenceMin: 70, referenceMax: 139 })).toBe(true)
+  })
+
+  it('previous が null で更新後も基準値が両方 null の場合は false', () => {
+    expect(referenceRangeChanged(null, { referenceMin: null, referenceMax: null })).toBe(false)
+  })
+})
+
+describe('recalcRecordsForMaster', () => {
+  it('該当項目名の referenceMin/referenceMax/isAbnormal を新基準で再計算する', () => {
+    const records = [
+      record('r1', [{ itemName: 'LDL', value: '160', referenceMin: 0, referenceMax: 139, isAbnormal: true }]),
+    ]
+    const results = recalcRecordsForMaster(records, 'LDL', 0, 180)
+    expect(results).toHaveLength(1)
+    expect(results[0].recordId).toBe('r1')
+    expect(results[0].items[0]).toMatchObject({ referenceMin: 0, referenceMax: 180, isAbnormal: false })
+  })
+
+  it('該当しない項目名の行には触れない', () => {
+    const records = [
+      record('r1', [
+        { itemName: 'LDL', value: '160', referenceMin: 0, referenceMax: 139, isAbnormal: true },
+        { itemName: '血圧', value: '120', referenceMin: 70, referenceMax: 130, isAbnormal: false },
+      ]),
+    ]
+    const results = recalcRecordsForMaster(records, 'LDL', 0, 200)
+    expect(results).toHaveLength(1)
+    expect(results[0].items.find(i => i.itemName === '血圧')).toEqual(
+      records[0].items.find(i => i.itemName === '血圧'),
+    )
+  })
+
+  it('再計算しても値に変化がない記録は結果に含めない', () => {
+    const records = [
+      record('r1', [{ itemName: 'LDL', value: '100', referenceMin: 0, referenceMax: 139, isAbnormal: false }]),
+    ]
+    // 基準値は同じ 0/139 のまま呼び出しても、対象記録のフィールドが既に一致していれば更新不要
+    const results = recalcRecordsForMaster(records, 'LDL', 0, 139)
+    expect(results).toEqual([])
+  })
+
+  it('該当項目名を含まない記録は結果に含めない', () => {
+    const records = [record('r1', [{ itemName: '血圧', value: '120' }])]
+    expect(recalcRecordsForMaster(records, 'LDL', 0, 139)).toEqual([])
+  })
+
+  it('複数記録のうち、実際に値が変化するものだけを返す', () => {
+    const records = [
+      // 既に新基準 (0/150) と同じ値が保存されている記録 → 再計算しても変化なし
+      record('r1', [{ itemName: 'LDL', value: '100', referenceMin: 0, referenceMax: 150, isAbnormal: false }]),
+      // 旧基準 (0/200) のままの記録 → 新基準 (0/150) では referenceMax・isAbnormal ともに変わる
+      record('r2', [{ itemName: 'LDL', value: '160', referenceMin: 0, referenceMax: 200, isAbnormal: false }]),
+    ]
+    const results = recalcRecordsForMaster(records, 'LDL', 0, 150)
+    expect(results.map(r => r.recordId)).toEqual(['r2'])
+    expect(results[0].items[0]).toMatchObject({ referenceMax: 150, isAbnormal: true })
+  })
+
+  it('数値でない値の項目は基準値変更後も isAbnormal=false のまま（変化なし扱い）', () => {
+    const records = [
+      record('r1', [{ itemName: 'HBs抗原', value: '陰性', referenceMin: null, referenceMax: null, isAbnormal: false }]),
+    ]
+    const results = recalcRecordsForMaster(records, 'HBs抗原', 0, 1)
+    // referenceMin/referenceMax 自体は null -> 0/1 に変わるため更新対象にはなる
+    expect(results).toHaveLength(1)
+    expect(results[0].items[0]).toMatchObject({ referenceMin: 0, referenceMax: 1, isAbnormal: false })
+  })
+})

--- a/web/src/lib/recalcAbnormal.ts
+++ b/web/src/lib/recalcAbnormal.ts
@@ -1,0 +1,102 @@
+// Issue #50: Web 版でも項目マスターの基準値変更を既存記録に再計算して反映するためのロジック。
+// Android の HealthRepository.evaluateAbnormal() / referenceRangeChanged()
+// （android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt:312-327）
+// と同じ判定結果になるように実装している。Firestore アクセスとは分離した純関数として切り出すことで、
+// 将来 Cloud Functions 側での再計算に寄せる場合にも判定ロジックをそのまま流用できるようにしている。
+import type { ExaminationItem, ExaminationRecord, ItemMaster } from '../types'
+
+/**
+ * Kotlin の String.toDoubleOrNull() に相当する判定を行う。
+ * `parseFloat` のような部分一致（例: "12kg" -> 12）は許容せず、文字列全体（前後の空白を除く）が
+ * 数値表現である場合のみ変換する。数値化できない値（"陰性" など）は null を返す。
+ *
+ * 経年グラフ用の `parseNumericValue`（./trend.ts）とは意図的に異なる実装であることに注意。
+ * あちらは Issue #28 の決定により parseFloat 相当（部分一致を許容）を採用しているが、
+ * 基準値外判定は Android の evaluateAbnormal と完全に一致させる必要があるため、
+ * ここでは toDoubleOrNull 相当の厳密な判定を用いる。
+ */
+export function toDoubleOrNull(raw: string): number | null {
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(trimmed)) return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Android の HealthRepository.evaluateAbnormal() と同じ判定を行う。
+ * - value が数値化できない場合 → false（基準値外ではない）
+ * - min が null → 下限チェックはスキップ
+ * - max が null → 上限チェックはスキップ
+ * - 下限未満 または 上限超過 → true
+ */
+export function evaluateAbnormal(value: string, min: number | null, max: number | null): boolean {
+  const numericValue = toDoubleOrNull(value)
+  if (numericValue === null) return false
+  const belowMin = min !== null ? numericValue < min : false
+  const aboveMax = max !== null ? numericValue > max : false
+  return belowMin || aboveMax
+}
+
+/**
+ * Android の HealthRepository.referenceRangeChanged() と同じ判定を行う。
+ * カテゴリ・お気に入りなど基準値以外の変更では true を返さない
+ * （＝呼び出し側で既存記録の全件再計算を避けるための最適化に使う）。
+ * previous が null（新規登録）の場合は「未設定」として扱う。
+ */
+export function referenceRangeChanged(
+  previous: Pick<ItemMaster, 'referenceMin' | 'referenceMax'> | null,
+  updated: Pick<ItemMaster, 'referenceMin' | 'referenceMax'>,
+): boolean {
+  const prevMin = previous ? previous.referenceMin : null
+  const prevMax = previous ? previous.referenceMax : null
+  return prevMin !== updated.referenceMin || prevMax !== updated.referenceMax
+}
+
+/** 再計算の結果、Firestore へ書き戻す必要がある記録1件分。 */
+export interface RecordRecalcResult {
+  recordId: string
+  items: ExaminationItem[]
+}
+
+/**
+ * 指定した項目名 (itemName) を含む記録を走査し、新しい基準値で
+ * referenceMin / referenceMax / isAbnormal を再計算する。
+ * 実際に値が変化した記録のみを結果に含める（変化がない記録は対象外＝不要な書き込みを避ける）。
+ *
+ * Android の upsertMaster() 内の再計算処理
+ * （existingItems を新基準で map し直す部分）に相当する。
+ */
+export function recalcRecordsForMaster(
+  records: ExaminationRecord[],
+  itemName: string,
+  referenceMin: number | null,
+  referenceMax: number | null,
+): RecordRecalcResult[] {
+  const results: RecordRecalcResult[] = []
+
+  for (const record of records) {
+    let changed = false
+    const items = record.items.map(item => {
+      if (item.itemName !== itemName) return item
+
+      const isAbnormal = evaluateAbnormal(item.value, referenceMin, referenceMax)
+      if (
+        item.referenceMin === referenceMin &&
+        item.referenceMax === referenceMax &&
+        item.isAbnormal === isAbnormal
+      ) {
+        return item
+      }
+
+      changed = true
+      return { ...item, referenceMin, referenceMax, isAbnormal }
+    })
+
+    if (changed) {
+      results.push({ recordId: record.id, items })
+    }
+  }
+
+  return results
+}


### PR DESCRIPTION
## 概要

Web 版の項目マスター画面で基準値（下限・上限）を変更しても既存の診断記録の `isAbnormal` が再計算されない問題を修正する。Android では `HealthRepository.upsertMaster()`（Issue #8 / PR #11）で既に対応済みの挙動を Web にも実装し、プラットフォーム間の判定不一致を解消する。

Closes #50

## 変更内容

1. `web/src/lib/recalcAbnormal.ts`（新規）
   - `evaluateAbnormal(value, min, max)`: Android の `HealthRepository.evaluateAbnormal()` と同じ判定を行う純関数。`toDoubleOrNull` で数値化し、下限未満／上限超過を判定する
   - `toDoubleOrNull(raw)`: Kotlin の `String.toDoubleOrNull()` 相当。既存の `web/src/lib/trend.ts` の `parseNumericValue`（`parseFloat` 相当・部分一致を許容）とは意図的に異なり、文字列全体が数値表現である場合のみ数値化する（"12kg" は null）
   - `referenceRangeChanged(previous, updated)`: Android の `HealthRepository.referenceRangeChanged()` と同じ判定。カテゴリ・お気に入りのみの変更では `false` を返す
   - `recalcRecordsForMaster(records, itemName, referenceMin, referenceMax)`: 全記録を走査し、該当 `itemName` の項目を新基準で再計算。実際に値が変化した記録のみを結果に含める（Firestore アクセスとは分離した純関数）
   - 単体テスト `recalcAbnormal.test.ts` を `trend.ts` / `trend.test.ts` と同じ構成で追加（下限未満／上限超過／範囲内／数値でない値／基準値 null の各ケースを網羅）

2. `web/src/firestoreService.ts`
   - `saveMaster()` を拡張: 保存前に既存マスターを `getDoc` で取得 → `referenceRangeChanged()` で基準値が変化したか判定 → 変化した場合のみ `fetchRecords()` で全記録を取得し `recalcRecordsForMaster()` で対象記録を算出 → `writeBatch`（500件ごとに分割）で `items[]` を更新
   - 基準値が変わらない場合（単位のみの変更など）は記録への書き込みは発生しない
   - `ItemMasters.tsx` の変更は不要と判断: 既存の `saving` state は `saveMaster()` の await 全体（再計算処理を含む）をカバーしているため、再計算中も「保存中...」ボタン表示がそのまま機能する

## 置いた前提（Issue の❓未解決の質問に対する無人実行判断）

Issue #50 の「❓未解決の質問」2件は代表の回答待ちのため、以下の前提を置いて実装した。

- **再計算方式**: Issue の提案どおり、Web クライアント側で全記録を取得して走査する方式（クライアント再計算）を採用した。Cloud Functions への移行は行っていない。ただし判定ロジック（`evaluateAbnormal` / `referenceRangeChanged` / `recalcRecordsForMaster`）は Firestore アクセスと分離した純関数として `web/src/lib/recalcAbnormal.ts` に切り出してあるため、将来 Cloud Functions 側の再計算に寄せる場合もそのまま流用できる
- **`category` / `isFavorite` の Web 編集 UI が無い件**: 本 PR のスコープ外として扱い、実装していない。別 Issue として起票すべきかは代表の判断を仰ぐ

## 受け入れ基準チェック

- [x] Web で項目マスターの基準値を変更すると、その項目を含む既存記録の `items[].referenceMin` / `referenceMax` / `isAbnormal` が Firestore 上で更新される
- [x] 基準値を変えず単位のみ変更した場合は、記録ドキュメントへの書き込みが発生しない
- [x] 判定ロジックが純関数として切り出され、vitest の単体テストで「下限未満 / 上限超過 / 範囲内 / 数値でない値 / 基準値 null」のケースを網羅している
- [ ] 再計算後に Android を起動して `restoreFromFirestore()` が走ると、Android 側の基準値外一覧も新しい判定になる（実機・エミュレータでの手動確認が必要。本 PR では未実施）
- [x] `npm --prefix web run lint` と `npm --prefix web run test` が通る

## テスト

- `npm --prefix web run lint` — 0 errors（既存の `ItemMasters.tsx` の `react-hooks/exhaustive-deps` warning 1件のみ、本 PR による変更ではない）
- `npm --prefix web run test` — 4 files / 53 tests all passed（`recalcAbnormal.test.ts` の24件を含む）
- `npx tsc -b`（web/）— エラーなし

## 未確認・フォローアップ事項

- 受け入れ基準の4番目（Android の `restoreFromFirestore()` 再同期後の見え方）は実機/エミュレータでの手動確認が必要。本 PR のコード変更だけではCI上で検証できていない
- `category` / `isFavorite` の Web 編集 UI 不在は別 Issue 起票の要否を代表に確認したい（Issue #50 内の未解決の質問を参照）
