### PR TITLE
web: 記録一覧のカラー直書きをトークン参照へ移行 (#59)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -298,7 +298,7 @@ h1 {
 h2 {
   font-size: 20px;
   font-weight: 700;
-  color: var(--text-h);
+  color: var(--color-text-primary);
   margin: 0 0 20px;
 }
 
@@ -321,8 +321,8 @@ h2 {
 
 .record-card {
   display: block;
-  background: var(--bg);
-  border: 1px solid var(--border);
+  background: var(--color-background);
+  border: 1px solid var(--color-outline);
   border-radius: 12px;
   padding: 16px 20px;
   text-decoration: none;
@@ -330,17 +330,17 @@ h2 {
 }
 .record-card:hover {
   box-shadow: 0 2px 12px rgba(0,0,0,0.08);
-  border-color: #1a7a6e;
+  border-color: var(--color-primary);
 }
 
-.record-date { font-size: 17px; font-weight: 600; color: var(--text-h); margin-bottom: 4px; }
-.record-facility { font-size: 14px; color: var(--text); margin-bottom: 8px; }
-.record-meta { display: flex; gap: 12px; font-size: 13px; color: var(--text); }
+.record-date { font-size: 17px; font-weight: 600; color: var(--color-text-primary); margin-bottom: 4px; }
+.record-facility { font-size: 14px; color: var(--color-text-secondary); margin-bottom: 8px; }
+.record-meta { display: flex; gap: 12px; font-size: 13px; color: var(--color-text-secondary); }
 
 .badge-abnormal {
-  background: #fff0f0;
-  color: #d32f2f;
-  border: 1px solid #f5c6c6;
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+  border: 1px solid color-mix(in srgb, var(--color-error) 30%, transparent);
   border-radius: 4px;
   padding: 1px 8px;
   font-size: 12px;


### PR DESCRIPTION
Closes #59

## 概要

`web/src/App.css` の「記録一覧」セクション（`/* ── 記録一覧 ── */` 〜 `/* ── 記録詳細 ── */` 直前、着手時点で 296〜350 行。起票時点の 293〜346 行から #57・#58 のマージで +3 行ずれています）の直書きカラーを `DESIGN.md` のトークン参照へ移行しました。

対象は `web/src/App.css` のみで、他セクション・`index.css`・Android 側には触れていません。

## 変更内容（表示色が変わる箇所）

| 要素 | 変更前 | 変更後 |
|---|---|---|
| `.record-card:hover` の枠線 | `#1a7a6e` | `var(--color-primary)`（`#00696C`） |
| `.badge-abnormal` の文字色 | `#d32f2f` | `var(--color-error)`（`#BA1A1A`） |
| `.badge-abnormal` の背景 | `#fff0f0` | `color-mix(in srgb, var(--color-error) 12%, transparent)`（`#FAFDFC` 上でおよそ `#F2E2E1`） |
| `.badge-abnormal` の枠線 | `#f5c6c6` | `color-mix(in srgb, var(--color-error) 30%, transparent)`（`#FAFDFC` 上でおよそ `#E7B9B8`） |

以下は旧トークンエイリアスから新トークン名への置き換えで、**値は変わらず表示上の変化はありません**（`index.css` のエイリアス定義自体は撤去していません。撤去は #60 の担当）:

- `h2 { color: var(--text-h) }` → `var(--color-text-primary)`（このセクション内に配置されたグローバル `h2` セレクタです）
- `.record-card { background: var(--bg); border: 1px solid var(--border) }` → `var(--color-background)` / `var(--color-outline)`
- `.record-date { color: var(--text-h) }` → `var(--color-text-primary)`
- `.record-facility` / `.record-meta { color: var(--text) }` → `var(--color-text-secondary)`

### 除外した直書き

- `.record-card:hover` の `box-shadow: 0 2px 12px rgba(0,0,0,0.08)` は影の `rgba()` で、`DESIGN.md` のトークン表に対応概念がないため置き換えていません。

## `.badge-abnormal` の判断（Issue 本文の「注意」への回答）

### 淡色（背景・枠線）の導出方法: `color-mix()` を採用（新規トークンは追加していません）

- `DESIGN.md` を確認しましたが、error の淡色（背景・枠線）に対応するトークンは定義されていません（`primary-hover` は `color-mix()` 由来である旨の記載があります）。
- Issue #57 で `#ffeaea` / `#f0faf9` の淡色を「新トークンを増やさず `color-mix()` で導出」する判断が採られており、`App.css` 内にも `color-mix(in srgb, var(--color-error) 12%, transparent)`（150行 `.btn-delete-account:hover`、260行 `.btn-danger:hover`、567行 `.error`）という **12% の慣例**がすでに存在します。
- 特段の理由がないため同じ流儀（`color-mix()`、12%）に揃えました。背景は既存慣例と同じ `12%`、枠線は視認性のため少し濃い `30%` としています（枠線は文字とのペアではないため WCAG AA 4.5:1 の対象外です）。

### コントラスト比の測定値

`.badge-abnormal` は `web/src/pages/RecordList.tsx` 内で `.record-card`（背景 `var(--color-background)` = `#FAFDFC`）の内側にのみ表示されます（他の背景色の上に置かれる箇所はありません）。この上で `color-mix(in srgb, var(--color-error) 12%, transparent)` を合成すると実効背景はおよそ `#F2E2E1` になります。

WCAG 2.1 の相対輝度式で計算した結果（Python で計算。実ブラウザでの測色ではありません）:

- 文字色 `#BA1A1A` × 背景 `#F2E2E1`（12%合成）: **コントラスト比 約 5.14:1** → AA（4.5:1）を満たす
- 参考: 背景の合成率を上げるほどコントラストは下がり、`20%` にすると約 4.46:1 で AA を割り込みます。`12%` には十分な余裕があります。

## テスト結果

WSL上、Node 24（`nvm use 24`）で実行:

- `npm --prefix web run lint` — 0 errors（`ItemMasters.tsx` の既存 warning 1件のみ、本PRと無関係）
- `npm --prefix web run test -- --run` — 3 files / 29 tests すべて成功
- `npm --prefix web run build` — 成功（chunk size warning は既存の未対応事項で本PRと無関係）

## 差分範囲の確認

`git diff -U0 -- web/src/App.css` のハンクはすべて 296〜350 行の「記録一覧」セクション内（301 / 324-325 / 333 / 336-338 / 341-343 行）に収まっています。担当セクション以外・`index.css`・Android 側は変更していません。

セクション内に `#1a7a6e` / `#d32f2f` は残っていません。

## 未確認事項

- 実ブラウザでの目視確認は行っていません。記録一覧はログイン後のFirebaseデータ表示が前提のため、この環境では再現していません。コントラストは上記の通り計算式で確認済みです。
