### PR TITLE
web: 記録詳細・入力フォームのカラー直書きをトークン参照へ移行 (#60)

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -356,7 +356,7 @@ h2 {
   margin-bottom: 16px;
 }
 
-.facility { font-size: 15px; color: var(--text); margin: -12px 0 20px; }
+.facility { font-size: 15px; color: var(--color-text-secondary); margin: -12px 0 20px; }
 
 .items-table {
   width: 100%;
@@ -366,21 +366,24 @@ h2 {
 .items-table th {
   text-align: left;
   padding: 10px 12px;
-  border-bottom: 2px solid var(--border);
-  color: var(--text);
+  border-bottom: 2px solid var(--color-outline);
+  color: var(--color-text-secondary);
   font-weight: 600;
   white-space: nowrap;
 }
 .items-table td {
   padding: 10px 12px;
-  border-bottom: 1px solid var(--border);
-  color: var(--text-h);
+  border-bottom: 1px solid var(--color-outline);
+  color: var(--color-text-primary);
 }
 .items-table .val { font-weight: 600; }
-.items-table .ref { color: var(--text); font-size: 13px; }
+.items-table .ref { color: var(--color-text-secondary); font-size: 13px; }
 .items-table .actions { white-space: nowrap; }
 
-.row-abnormal td { background: #fff8f8; color: #c62828; }
+.row-abnormal td {
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--color-error);
+}
 .row-abnormal .val { font-weight: 700; }
 
 /* ── 入力フォーム ────────────────────────────────────── */
@@ -392,17 +395,17 @@ h2 {
   flex-direction: column;
   gap: 6px;
 }
-.form-row label { font-size: 14px; font-weight: 600; color: var(--text-h); }
+.form-row label { font-size: 14px; font-weight: 600; color: var(--color-text-primary); }
 .form-row input {
   padding: 10px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-outline);
   border-radius: 8px;
   font-size: 15px;
-  color: var(--text-h);
-  background: var(--bg);
+  color: var(--color-text-primary);
+  background: var(--color-background);
   max-width: 320px;
 }
-.required { color: #d32f2f; }
+.required { color: var(--color-error); }
 
 .items-section { display: flex; flex-direction: column; gap: 10px; }
 .items-header {
@@ -411,19 +414,22 @@ h2 {
   align-items: center;
   font-size: 14px;
   font-weight: 600;
-  color: var(--text-h);
+  color: var(--color-text-primary);
 }
 
 .item-row {
   display: flex;
   gap: 8px;
   align-items: center;
-  background: var(--bg);
-  border: 1px solid var(--border);
+  background: var(--color-background);
+  border: 1px solid var(--color-outline);
   border-radius: 8px;
   padding: 10px 12px;
 }
-.item-row.item-abnormal { border-color: #f5c6c6; background: #fff8f8; }
+.item-row.item-abnormal {
+  border-color: color-mix(in srgb, var(--color-error) 30%, transparent);
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+}
 
 .item-fields { display: flex; gap: 8px; flex: 1; flex-wrap: wrap; }
 
@@ -438,13 +444,13 @@ h2 {
 .item-fields input,
 .item-fields select {
   padding: 8px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-outline);
   border-radius: 6px;
   font-size: 14px;
   width: 100%;
   box-sizing: border-box;
-  background: var(--bg);
-  color: var(--text-h);
+  background: var(--color-background);
+  color: var(--color-text-primary);
 }
 
 .form-actions { display: flex; gap: 12px; justify-content: flex-end; margin-top: 8px; }


### PR DESCRIPTION
Closes #60

## 概要

`web/src/App.css` の担当2セクション（記録詳細・入力フォーム）のカラーコード直書きを `DESIGN.md` のトークン参照へ移行した。あわせて、両セクション内に残っていた移行用エイリアス（`--text` / `--text-h` / `--bg` / `--border`）参照を新トークン名へ書き換えた。

## 対象範囲・差分の位置

`git diff -U0 -- web/src/App.css` のハンクはすべて 359〜452行目に収まっており、担当2セクション内のみである（記録詳細 350〜385行、入力フォーム 386〜451行）。

```
@@ -359 +359 @@   .facility
@@ -369,2 +369,2 @@ .items-table th
@@ -376,2 +376,2 @@ .items-table td
@@ -380 +380 @@   .items-table .ref
@@ -383 +383,4 @@ .row-abnormal td
@@ -395 +398 @@   .form-row label
@@ -398 +401 @@   .form-row input (border)
@@ -401,2 +404,2 @@ .form-row input (color/background)
@@ -405 +408 @@   .required
@@ -414 +417 @@   .items-header
@@ -421,2 +424,2 @@ .item-row (background/border)
@@ -426 +429,4 @@ .item-row.item-abnormal
@@ -441 +447 @@   .item-fields input,select (border)
@@ -446,2 +452,2 @@ .item-fields input,select (background/color)
```

担当セクション外（レイアウト・共通ボタン・ログイン画面・記録一覧・項目マスター等）は変更していない。

## 表示色が変わる箇所（一覧）

| 箇所 | 変更前 | 変更後 | 表示色 |
|---|---|---|---|
| `.row-abnormal td` の文字色 | `#c62828` | `var(--color-error)` = `#BA1A1A` | **変わる**（若干暗い赤に） |
| `.row-abnormal td` の背景 | `#fff8f8` | `color-mix(in srgb, var(--color-error) 12%, transparent)` ≈ `#F2E2E1` | **変わる**（ごく僅かにピンクが濃く/暖色寄りに） |
| `.required` の文字色 | `#d32f2f` | `var(--color-error)` = `#BA1A1A` | **変わる**（若干暗い赤に） |
| `.item-row.item-abnormal` の枠線 | `#f5c6c6` | `color-mix(in srgb, var(--color-error) 30%, transparent)` ≈ `#E7B9B8` | **変わる**（ごく僅かに濃く） |
| `.item-row.item-abnormal` の背景 | `#fff8f8` | `color-mix(in srgb, var(--color-error) 12%, transparent)` ≈ `#F2E2E1` | **変わる**（ごく僅かにピンクが濃く/暖色寄りに） |
| `.facility` / `.items-table th,td,.ref` / `.form-row label,input` / `.items-header` / `.item-row` 背景・枠線 / `.item-fields input,select` の `var(--text)` `var(--text-h)` `var(--bg)` `var(--border)` → `var(--color-text-secondary)` `var(--color-text-primary)` `var(--color-background)` `var(--color-outline)` | 旧トークン | 新トークン | **変わらない**（`index.css` でエイリアスが同値を指しているため、値としては同一。参照名の書き換えのみ） |

## 淡色の導出方法（Issue #59 と揃えた）

`DESIGN.md` の「カラートークン」表を確認したが、`error` の淡色（背景・枠線）に対応するトークンは定義されていない（`primary-hover` のみ `color-mix()` 由来である旨の記載がある）。Issue #59・#57 で「新規トークンを増やさず `color-mix()` で導出する」判断が採られており、`App.css` 内にも 12% の慣例（150行 `.btn-delete-account:hover`、260行 `.btn-danger:hover`、567行 `.error`）が既にある。特段の理由がないため同じ流儀（背景 12%・枠線 30%）に揃えた。新規トークンは追加していない。

## コントラスト比の測定値（WCAG 2.1 AA）

**背景の重なりを確認**: `.items-table`（記録詳細）と `.item-row`（入力フォーム）はいずれも `.main-content` 直下に置かれ、`.main-content` / `.layout` 自体に背景指定はないため、実際の描画背景は `:root` の `background: var(--bg)` = `--color-background` = `#FAFDFC` になる（`RecordDetail.tsx` / `RecordForm.tsx` を確認。カード等の別背景コンポーネントには包まれていない）。これは Issue #59 の `.badge-abnormal`（`.record-card` の背景 = 同じ `#FAFDFC`）と同一の背景であるため、同じ計算式・同じ結果になる。

- `color-mix(in srgb, var(--color-error) 12%, transparent)` を `#FAFDFC` に合成すると実効背景は `rgba(186,26,26,0.12)` を重ねた結果として **約 `#F2E2E1`（242, 226, 225）** になる（自前で再計算し、Issue #59 の値と一致することを確認済み）。
- 文字色 `#BA1A1A` × 背景 `#F2E2E1`: **コントラスト比 約 5.14:1** → AA（4.5:1）を満たす。
- 参考（Issue #59 で確認済みの傾向）: 合成率を上げるほどコントラストは下がり、20% にすると 4.5:1 を割り込む。12% には十分な余裕がある。

補足2点:
- `.items-table .ref`（セレクタ詳細度 (0,2,0)）は `.row-abnormal td`（詳細度 (0,1,1)）より強いため、基準値外行でも基準値セル（`.ref`）の文字色は従来どおり `var(--color-text-secondary)`（`#3F4948`）のまま変わらない（この挙動は移行前から同じで、本 PR による変更ではない）。念のため計算すると `#3F4948` × 背景 `#F2E2E1` は約 7.4:1 で AA を満たす。
- `.item-row.item-abnormal` 自体は文字色を上書きしていない。内部の `input` / `select` は `.item-fields input, select` の規則で不透明な `background: var(--color-background)`（`#FAFDFC`）を独自に持つため、ピンク背景の上に直接テキストが乗る箇所はなく、影響は枠線と行の余白部分のみ。

## 移行用エイリアス撤去の判断: **見送り**

撤去前の確認コマンド:

```
grep -rn -E 'var\(--(text|text-h|bg|border)\)' web/src/
```

結果は **0件ではなく25件**残っている。担当2セクション内はすべて新トークン名へ書き換え済みだが、担当外の以下箇所に参照が残っているため、エイリアス4つ（`--text` / `--text-h` / `--bg` / `--border`）は `index.css` から撤去していない。

- `web/src/App.css` 107〜124行目（アカウント削除モーダル、Issue #34。#56〜#60 のどの Issue の担当範囲でもない）
- `web/src/App.css` 460〜479行目（項目マスター）
- `web/src/App.css` 497〜519行目（経年グラフ）
- `web/src/App.css` 547〜563行目（基準値外一覧、Issue #33）
- `web/src/index.css` 38, 39, 55, 70, 100行目（`:root` ブロック外の body/`#root`/`h1,h2`/`code` 共通スタイル自体が旧トークン名を参照している）

これらは担当セクション外であり、勝手に書き換えるとスコープ外の変更になるため着手していない。**エイリアス撤去には、上記5箇所を新トークン名へ移行する追加対応（新規 Issue）が別途必要**。`index.css` 24〜25行目のコメント（「撤去は画面別置き換えが完了した最後の Issue（#60）が担当する」）も、この状況を踏まえて追加 Issue 側で更新することを想定している（本 PR では変更していない）。

## 移行完了の総括

本 PR で `App.css` の**担当2セクションの直書き解消**は完了したが、上記の通り**エイリアス4つの撤去は未完**であるため、Web のカラートークン移行（#56〜#60）全体としては完了していない。

- `App.css` 全体からのカラーコード直書き検索: `grep -n '#[0-9a-fA-F]\{3,6\}' web/src/App.css`
  - 残るのは `.btn-google`（203〜205行目）の `#fff` / `#3c4043` / `#dadce0` のみ。これは Issue #58 で「Google サインインボタンの標準配色（Google ブランドガイドライン指定色）であり、プロダクトのブランドカラーではないため直書きのまま残す」と判断済みのもので、正常。
  - それ以外のカラーコード直書きは `App.css` 全体で0件（担当2セクションの `#c62828` / `#d32f2f` / `#fff8f8` / `#f5c6c6` も含めすべて解消済み）。
- `rgba()` について、トークン表に対応概念がないため除外・現状維持としたもの（本 PR での新規追加はなし、すべて既存）:
  - `.nav-link` / `.nav-name` / `.btn-logout` / `.btn-delete-account-link`（37, 45, 64, 69, 78, 83行目）: ナビゲーションバー上の半透明白文字・背景
  - `.modal-backdrop`（98行目）: モーダルの半透明黒背景
  - `.btn-google:hover`（212行目）・記録カード等の box-shadow（332行目）: 半透明黒の影
- 残っているエイリアス参照（上記5箇所）は追加対応が必要。

## テスト結果

WSL 上で Node 24（`nvm use 24`）に切り替えて実行（Windows 側 node だと UNC パスで失敗するため）。

- `npm --prefix web run lint`: 0 errors（`ItemMasters.tsx` の既存 warning 1件のみ、本 PR とは無関係）
- `npm --prefix web run test`: 3 files / 29 tests すべて成功
- `npm --prefix web run build`: 成功（`tsc -b && vite build`）

## 未確認事項

実ブラウザでの目視確認は行っていない。記録詳細・入力フォームはログイン後の Firestore データ表示が前提のため、この作業環境では再現できなかった。表示色の変化はコントラスト計算式で確認済みだが、実際のレンダリングでの見た目確認は未実施。
