### PR TITLE
web: 残り25箇所の旧トークン参照を新トークン名へ置き換え、移行用エイリアスを撤去 (#72)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -104,7 +104,7 @@ Web（`web/`）で新規に追加する画面は、Android と同じ意味のト
 - **Canvas 描画（Chart.js 等）では `var()` がブラウザの Canvas 2D API 上で解決されないため**、`getComputedStyle(document.documentElement).getPropertyValue('--color-primary')` で実測値の文字列を取得してから渡す（`web/src/components/TrendChart.tsx` 参照）
 - 新規トークンが必要になったら、この表と Android 側のカラートークン表の両方に追記し、値を一致させる
 - 既存 Web 4画面のうち `ItemMasters` と経年グラフ画面は既にトークン化済みで直書きは0件。残る `RecordList` / `RecordDetail` / `RecordForm` の直書きカラーコードの是正は、本トークン基盤（Issue #56）を前提として画面別の後続 Issue #57〜#60 が担当する
-- 移行用エイリアス（`--text-h` / `--text` / `--bg` / `--border`）: `App.css` の既存参照が壊れないよう、新トークンの `var()` 別名として `index.css` に残置している。画面別の置き換えが完了した最後の Issue（#60）が撤去する
+- 移行用エイリアス（`--text-h` / `--text` / `--bg` / `--border`）: `App.css` の既存参照が壊れないよう、新トークンの `var()` 別名として `index.css` に一時的に残置していたが、Web カラートークン移行（Issue #56〜#60, #72）の完了に伴い、参照箇所（`App.css` / `index.css` 計25箇所）をすべて新トークン名へ置き換えたうえで Issue #72 にて撤去済み（`index.css` からエイリアス4定義を削除）。以後、旧トークン名（`--text-h` / `--text` / `--bg` / `--border`）は使用しない
 - **外部ブランド由来の色は例外として直書きを許容する**（2026-09-09 追記, Issue #58）: `.btn-google`（Google サインインボタン）の配色 `#fff` / `#3c4043` / `#dadce0` は Google ブランドガイドラインの指定色であり、プロダクトのブランドカラーではないため、トークンへ機械的に寄せない。直書きのまま残し、理由をコード側のコメントで明示する。`--color-surface` の `#FFFFFF` とはたまたま同じ値になるだけで意味が異なるため代用しない
 
 ## プロジェクト固有ルール

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -104,9 +104,9 @@
 }
 
 .modal-card {
-  background: var(--bg);
-  color: var(--text-h);
-  border: 1px solid var(--border);
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-outline);
   border-radius: 16px;
   padding: 28px;
   width: 100%;
@@ -116,12 +116,12 @@
 }
 .modal-card h2 { margin: 0 0 12px; font-size: 18px; }
 
-.modal-message { color: var(--text); font-size: 14px; margin: 0 0 12px; line-height: 1.6; white-space: pre-line; }
+.modal-message { color: var(--color-text-secondary); font-size: 14px; margin: 0 0 12px; line-height: 1.6; white-space: pre-line; }
 
 .modal-list {
   margin: 0 0 16px;
   padding-left: 20px;
-  color: var(--text-h);
+  color: var(--color-text-primary);
   font-size: 14px;
   line-height: 1.8;
 }
@@ -457,7 +457,7 @@ h2 {
 
 /* ── 項目マスター ────────────────────────────────────── */
 
-.note-small { font-size: 13px; color: var(--text); margin: -12px 0 20px; }
+.note-small { font-size: 13px; color: var(--color-text-secondary); margin: -12px 0 20px; }
 
 .master-form { margin-bottom: 24px; }
 .master-form-row {
@@ -472,11 +472,11 @@ h2 {
 
 .master-form-row input {
   padding: 10px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-outline);
   border-radius: 8px;
   font-size: 14px;
-  background: var(--bg);
-  color: var(--text-h);
+  background: var(--color-background);
+  color: var(--color-text-primary);
   width: 100%;
   box-sizing: border-box;
 }
@@ -494,18 +494,18 @@ h2 {
 
 .trend-item-select {
   padding: 10px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-outline);
   border-radius: 8px;
   font-size: 14px;
-  background: var(--bg);
-  color: var(--text-h);
+  background: var(--color-background);
+  color: var(--color-text-primary);
   min-width: 200px;
 }
 
 .trend-period-tabs {
   display: flex;
   gap: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-outline);
   border-radius: 8px;
   padding: 3px;
 }
@@ -516,7 +516,7 @@ h2 {
   border-radius: 6px;
   padding: 6px 16px;
   font-size: 13px;
-  color: var(--text);
+  color: var(--color-text-secondary);
   cursor: pointer;
 }
 /* アクティブ状態は primary トークンの文字色＋枠線で表現し、白文字とのコントラスト計算不要にする */
@@ -544,23 +544,23 @@ h2 {
 .abnormal-table th {
   text-align: left;
   padding: 10px 12px;
-  border-bottom: 2px solid var(--border);
-  color: var(--text);
+  border-bottom: 2px solid var(--color-outline);
+  color: var(--color-text-secondary);
   font-weight: 600;
   white-space: nowrap;
 }
 .abnormal-table td {
   padding: 10px 12px;
-  border-bottom: 1px solid var(--border);
-  color: var(--text-h);
+  border-bottom: 1px solid var(--color-outline);
+  color: var(--color-text-primary);
 }
 .abnormal-table .val { font-weight: 700; color: var(--color-error); }
-.abnormal-table .ref { color: var(--text); font-size: 13px; }
+.abnormal-table .ref { color: var(--color-text-secondary); font-size: 13px; }
 
 .abnormal-row { cursor: pointer; }
 .abnormal-row:hover,
 .abnormal-row:focus-visible {
-  background: var(--border);
+  background: var(--color-outline);
   outline: none;
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -21,13 +21,6 @@
 
   --code-bg: #f4f3ec;
 
-  /* 移行用エイリアス（Issue #56）。web/src/App.css から旧トークン名で計47箇所参照されているため、
-     新トークンの別名として定義を残す。撤去は画面別置き換えが完了した最後の Issue（#60）が担当する */
-  --text-h: var(--color-text-primary);
-  --text: var(--color-text-secondary);
-  --bg: var(--color-background);
-  --border: var(--color-outline);
-
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
   --mono: ui-monospace, Consolas, monospace;
@@ -35,8 +28,8 @@
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
   color-scheme: light;
-  color: var(--text);
-  background: var(--bg);
+  color: var(--color-text-secondary);
+  background: var(--color-background);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -52,7 +45,7 @@
   max-width: 100%;
   margin: 0 auto;
   text-align: center;
-  border-inline: 1px solid var(--border);
+  border-inline: 1px solid var(--color-outline);
   min-height: 100svh;
   display: flex;
   flex-direction: column;
@@ -67,7 +60,7 @@ h1,
 h2 {
   font-family: var(--heading);
   font-weight: 500;
-  color: var(--text-h);
+  color: var(--color-text-primary);
 }
 
 h1 {
@@ -97,7 +90,7 @@ code,
   font-family: var(--mono);
   display: inline-flex;
   border-radius: 4px;
-  color: var(--text-h);
+  color: var(--color-text-primary);
 }
 
 code {


### PR DESCRIPTION
## 概要

Issue #56〜#60 で完了させた Web カラートークン移行の積み残し（Issue #72）を対応しました。
`App.css` / `index.css` に残っていた旧トークン参照25箇所を新トークン名へ置き換え、移行用エイリアス（`--text-h` / `--text` / `--bg` / `--border`）を撤去しています。

Closes #72

## 対応内容

### 1. `App.css`（20箇所）

直書きの16進カラーが0件だったため #57〜#60 の対象外になっていた、次の4セクションを置き換えました。

- アカウント削除モーダル（Issue #34）
- 項目マスター
- 経年グラフ
- 基準値外一覧（Issue #33 / T-602）

置き換え対応表:

| 旧 | 新 |
|---|---|
| `var(--text-h)` | `var(--color-text-primary)` |
| `var(--text)` | `var(--color-text-secondary)` |
| `var(--bg)` | `var(--color-background)` |
| `var(--border)` | `var(--color-outline)` |

### 2. `index.css`（5箇所）

- `:root` ブロック内の `color: var(--text)` → `color: var(--color-text-secondary)`
- `:root` ブロック内の `background: var(--bg)` → `background: var(--color-background)`
  （この2箇所はエイリアス自身を参照していたため、エイリアス定義を消す前に先に置き換えました）
- `#root` の `border-inline: 1px solid var(--border)` → `var(--color-outline)`
- `h1, h2` の `color: var(--text-h)` → `var(--color-text-primary)`
- `code, .counter` の `color: var(--text-h)` → `var(--color-text-primary)`

### 3. エイリアスの撤去

置き換え後に参照0件を確認してから、`index.css` の `:root` から次の4行を削除しました。

```css
--text-h: var(--color-text-primary);
--text: var(--color-text-secondary);
--bg: var(--color-background);
--border: var(--color-outline);
```

### 4. `DESIGN.md` の更新

「移行用エイリアス…画面別の置き換えが完了した最後の Issue（#60）が撤去する」の記述を、Issue #72 で撤去済みである旨に更新しました。

## 表示色について

**エイリアスは既に新トークンを指していたため（例: `--text: var(--color-text-secondary)`）、参照名を置き換えても算出される色は同一です。純粋な名前の付け替えのみで、値そのものは一切変更していません。** 差分は変数名の置換のみであることを `git diff` で確認済みです。

## 確認結果

- [x] `grep -rn -E 'var\(--(text|text-h|bg|border)\)' web/src/` → **0件**（確認済み）
- [x] `index.css` から移行用エイリアス4つ（`--text-h` / `--text` / `--bg` / `--border`）を削除済み
- [x] `--code-bg` / `--sans` / `--heading` / `--mono` は削除していません（`index.css` に残存を確認済み）
- [x] 置き換えによる色の値の変更なし（`var()` の参照名変更のみ、`git diff` で確認）
- [x] `DESIGN.md` のエイリアスに関する記述を撤去済みの内容へ更新
- [x] `npm --prefix web run lint` → 成功（既存の警告1件〔`ItemMasters.tsx` の `react-hooks/exhaustive-deps`〕のみ。本 PR の変更とは無関係）
- [x] `npm --prefix web run test -- --run` → 4 files / 53 tests すべて成功
- [x] `npm --prefix web run build` → 成功

## 未確認事項

- 実ブラウザでの見た目の目視確認は行っていません。エイリアスが元々新トークンへの `var()` 別名であったこと、および `git diff` が変数名の置換のみであることから表示色は変わらない想定ですが、実機・実ブラウザでの確認は代表側でお願いします。

## Web カラートークン移行の総括（Issue #56〜#60, #72 完了）

本 PR をもって Web 版のカラートークン移行がすべて完了します。

### `App.css` の直書き16進カラー残存確認

```
$ grep -n '#[0-9a-fA-F]\{3,6\}' web/src/App.css
202:     （Issue #58）。--color-surface の #FFFFFF はたまたま同じ値になるだけで意味が異なるため代用しない */
203:  background: #fff;
204:  color: #3c4043;
205:  border: 1px solid #dadce0;
```

`.btn-google`（Google サインインボタン）の3行のみが残存しており、これは正常です。Issue #58 にて、Google ブランドガイドラインの指定色であり自社ブランドカラーではないため、トークン化せず直書きのまま残す判断がされています。

### `index.css` の `:root` の最終状態

- カラートークン（`--color-*`）: Issue #56〜#57 で定義した本来のトークンのみが残存
- `--code-bg`: 対応するトークン概念が `DESIGN.md` にないため、Issue #56 の判断どおり存置
- `--sans` / `--heading` / `--mono`: フォントトークンのため対象外、そのまま存置
- 移行用エイリアス（`--text-h` / `--text` / `--bg` / `--border`）: 本 PR にて撤去済み。旧トークン名への参照は `web/src/` 全体で0件です

以上により、Web 版の画面はすべて新トークン（`--color-*`）のみを参照する状態になりました。
