### PR TITLE
fix(web): 直接入力の項目名が1文字で消える不具合を修正 (#51)

### DIFF
--- a/web/src/lib/recordFormRow.test.ts
+++ b/web/src/lib/recordFormRow.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CUSTOM_ITEM_OPTION_VALUE,
+  createEmptyRow,
+  selectItemName,
+  setCustomItemName,
+  toSavableItems,
+  updateRowField,
+  type FormItemRow,
+} from './recordFormRow'
+import type { ItemMaster } from '../types'
+
+const masters: ItemMaster[] = [
+  { itemName: 'LDL', unit: 'mg/dL', referenceMin: 0, referenceMax: 139 },
+  { itemName: '血圧', unit: 'mmHg', referenceMin: 70, referenceMax: 130 },
+]
+
+describe('createEmptyRow', () => {
+  it('空の行を作る（isCustom は false）', () => {
+    const row = createEmptyRow('k1')
+    expect(row.key).toBe('k1')
+    expect(row.isCustom).toBe(false)
+    expect(row.item.itemName).toBe('')
+  })
+})
+
+describe('selectItemName', () => {
+  it('「直接入力」を選ぶと isCustom=true になり、itemName は空文字にリセットされる', () => {
+    const row = createEmptyRow('k1')
+    const next = selectItemName(row, CUSTOM_ITEM_OPTION_VALUE, masters)
+    expect(next.isCustom).toBe(true)
+    expect(next.item.itemName).toBe('')
+  })
+
+  it('「直接入力」を選んだ時点では CUSTOM_ITEM_OPTION_VALUE が itemName に入らない', () => {
+    const row = createEmptyRow('k1')
+    const next = selectItemName(row, CUSTOM_ITEM_OPTION_VALUE, masters)
+    expect(next.item.itemName).not.toBe(CUSTOM_ITEM_OPTION_VALUE)
+  })
+
+  it('マスターの項目名を選ぶと基準値・単位が補完され、isCustom は false になる', () => {
+    const row: FormItemRow = { ...createEmptyRow('k1'), isCustom: true }
+    const next = selectItemName(row, 'LDL', masters)
+    expect(next.isCustom).toBe(false)
+    expect(next.item.itemName).toBe('LDL')
+    expect(next.item.unit).toBe('mg/dL')
+    expect(next.item.referenceMin).toBe(0)
+    expect(next.item.referenceMax).toBe(139)
+  })
+
+  it('マスターにない値を選んだ場合（"項目を選択" =空文字など）は基準値を補完しない', () => {
+    const row = createEmptyRow('k1')
+    const next = selectItemName(row, '', masters)
+    expect(next.item.itemName).toBe('')
+    expect(next.item.unit).toBe('')
+  })
+})
+
+describe('setCustomItemName（直接入力欄の制御コンポーネント化）', () => {
+  it('1文字ずつ入力しても isCustom は true のまま保たれ、itemName が更新される', () => {
+    let row = selectItemName(createEmptyRow('k1'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    row = setCustomItemName(row, '随')
+    expect(row.isCustom).toBe(true)
+    expect(row.item.itemName).toBe('随')
+
+    row = setCustomItemName(row, '随時')
+    expect(row.isCustom).toBe(true)
+    expect(row.item.itemName).toBe('随時')
+
+    row = setCustomItemName(row, '随時血糖')
+    expect(row.isCustom).toBe(true)
+    expect(row.item.itemName).toBe('随時血糖')
+  })
+
+  it('複数文字を最後まで入力できる（1文字目で消えない）', () => {
+    let row = selectItemName(createEmptyRow('k1'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    for (const ch of '随時血糖') {
+      row = setCustomItemName(row, row.item.itemName + ch)
+      expect(row.isCustom).toBe(true)
+    }
+    expect(row.item.itemName).toBe('随時血糖')
+  })
+})
+
+describe('updateRowField', () => {
+  it('itemName 以外のフィールド（value）を更新できる', () => {
+    const row = createEmptyRow('k1')
+    const next = updateRowField(row, 'value', '100')
+    expect(next.item.value).toBe('100')
+  })
+
+  it('基準値外の値を入力すると isAbnormal が true になる（既存ロジックを維持）', () => {
+    let row = selectItemName(createEmptyRow('k1'), 'LDL', masters)
+    row = updateRowField(row, 'value', '160')
+    expect(row.item.isAbnormal).toBe(true)
+  })
+
+  it('基準値内の値では isAbnormal が false になる', () => {
+    let row = selectItemName(createEmptyRow('k1'), 'LDL', masters)
+    row = updateRowField(row, 'value', '100')
+    expect(row.item.isAbnormal).toBe(false)
+  })
+})
+
+describe('toSavableItems', () => {
+  it('直接入力で入力した項目名がそのまま items[].itemName になる', () => {
+    let row = selectItemName(createEmptyRow('k1'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    row = setCustomItemName(row, '随時血糖')
+    row = updateRowField(row, 'value', '120')
+    const items = toSavableItems([row])
+    expect(items).toEqual([
+      { itemName: '随時血糖', value: '120', unit: '', referenceMin: null, referenceMax: null, isAbnormal: false },
+    ])
+  })
+
+  it('直接入力を選んで何も入力しなかった行は保存対象から除外される', () => {
+    const row = selectItemName(createEmptyRow('k1'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    expect(toSavableItems([row])).toEqual([])
+  })
+
+  it('CUSTOM_ITEM_OPTION_VALUE がそのまま itemName として保存される経路は存在しない', () => {
+    // selectItemName の実装上、通常は起こらないが、万一 itemName に '__custom__' が
+    // 混入していたケースを想定した防御的テスト（toSavableItems 側のガード）。
+    const row: FormItemRow = {
+      key: 'k1',
+      isCustom: true,
+      item: { itemName: CUSTOM_ITEM_OPTION_VALUE, value: '', unit: '', referenceMin: null, referenceMax: null, isAbnormal: false },
+    }
+    expect(toSavableItems([row])).toEqual([])
+  })
+
+  it('マスターから選択した行と直接入力の行を混在させても、それぞれ正しく保存される', () => {
+    let masterRow = selectItemName(createEmptyRow('k1'), 'LDL', masters)
+    masterRow = updateRowField(masterRow, 'value', '100')
+
+    let customRow = selectItemName(createEmptyRow('k2'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    customRow = setCustomItemName(customRow, 'カスタム項目')
+    customRow = updateRowField(customRow, 'value', '5')
+
+    const items = toSavableItems([masterRow, customRow])
+    expect(items.map(i => i.itemName)).toEqual(['LDL', 'カスタム項目'])
+  })
+
+  it('項目名が空文字の行は除外する（既存の挙動を維持）', () => {
+    const row = createEmptyRow('k1')
+    expect(toSavableItems([row])).toEqual([])
+  })
+})
+
+describe('行の追加・削除でモードがずれないこと（key ベースで管理しているため配列操作の影響を受けない）', () => {
+  it('複数行のうち特定の行だけを直接入力モードにしても、他の行の状態は変わらない', () => {
+    const rowA = selectItemName(createEmptyRow('a'), 'LDL', masters)
+    const rowB = selectItemName(createEmptyRow('b'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    const rowC = createEmptyRow('c')
+    const rows = [rowA, rowB, rowC]
+
+    expect(rows.map(r => r.isCustom)).toEqual([false, true, false])
+  })
+
+  it('先頭の行を削除しても、残りの行は自分の key に紐づく isCustom を保ったまま（インデックスに依存しない）', () => {
+    const rowA = selectItemName(createEmptyRow('a'), 'LDL', masters)
+    const rowB = selectItemName(createEmptyRow('b'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    const rowC = createEmptyRow('c')
+    const rows = [rowA, rowB, rowC]
+
+    // rowA（先頭、インデックス0）を削除 -> 削除前は rowB がインデックス1、削除後はインデックス0になる
+    const afterRemove = rows.filter(r => r.key !== 'a')
+
+    // インデックスは変わるが、isCustom はそれぞれの行オブジェクトに紐づいているため
+    // rowB（今はインデックス0）が isCustom=true のまま、rowC（今はインデックス1）は false のまま
+    expect(afterRemove.map(r => r.key)).toEqual(['b', 'c'])
+    expect(afterRemove.find(r => r.key === 'b')?.isCustom).toBe(true)
+    expect(afterRemove.find(r => r.key === 'c')?.isCustom).toBe(false)
+  })
+
+  it('行を追加しても既存行の isCustom は変わらない', () => {
+    const rowA = selectItemName(createEmptyRow('a'), CUSTOM_ITEM_OPTION_VALUE, masters)
+    const rows = [rowA, createEmptyRow('b')]
+    expect(rows.find(r => r.key === 'a')?.isCustom).toBe(true)
+  })
+})

--- a/web/src/lib/recordFormRow.ts
+++ b/web/src/lib/recordFormRow.ts
@@ -1,0 +1,109 @@
+// Issue #51: RecordForm の検査項目行1件分の状態遷移を、React コンポーネントから切り出した純関数群。
+// 「直接入力を選んでいる」という UI 状態（isCustom）を item.itemName とは独立に保持することで、
+// 次の2つの不具合を構造的に起こり得なくする。
+//   1. 1文字入力した時点で直接入力欄がアンマウントされ、入力できなくなる
+//      （旧実装は item.itemName === '__custom__' を表示条件にしていたため）
+//   2. '__custom__' という一時的な選択値がそのまま項目名として Firestore に保存される
+//
+// 行の識別には配列インデックスではなく安定した `key`（RecordForm 側で行の追加時に採番し、
+// 削除時もその行の key ごと配列から取り除かれるだけ）を使う。isCustom は各行オブジェクト自身に
+// 紐づくフラグなので、他の行の追加・削除の影響を受けない（インデックスのずれが起こり得ない）。
+import type { ExaminationItem, ItemMaster } from '../types'
+
+/** 項目名 <select> で「直接入力」を選んだことを表す一時的な値。item.itemName には絶対に入らない。 */
+export const CUSTOM_ITEM_OPTION_VALUE = '__custom__'
+
+/** RecordForm の検査項目1行分の状態。 */
+export interface FormItemRow {
+  /** 行の安定識別子。追加・削除しても他の行とずれないようにするためのキー（配列インデックスは使わない） */
+  key: string
+  /** Firestore に保存される実体 */
+  item: ExaminationItem
+  /** 「直接入力モード」かどうかを表す表示専用フラグ。item / Firestore には保存されない */
+  isCustom: boolean
+}
+
+export function createEmptyItem(): ExaminationItem {
+  return {
+    itemName: '', value: '', unit: '',
+    referenceMin: null, referenceMax: null, isAbnormal: false,
+  }
+}
+
+export function createEmptyRow(key: string): FormItemRow {
+  return { key, item: createEmptyItem(), isCustom: false }
+}
+
+/** 既存の updateItem 内にあった isAbnormal 再計算ロジック（挙動を変えずに切り出したもの）。 */
+function recalcAbnormal(item: ExaminationItem): ExaminationItem {
+  const num = parseFloat(item.value)
+  const isAbnormal = !isNaN(num) && (
+    (item.referenceMin != null && num < item.referenceMin) ||
+    (item.referenceMax != null && num > item.referenceMax)
+  )
+  return { ...item, isAbnormal }
+}
+
+/**
+ * 項目名 <select> の onChange 用。
+ * - '__custom__' が選ばれた場合: isCustom=true にし、itemName はマスターから引き継がず空文字にリセットする。
+ *   これにより '__custom__' という文字列が item.itemName に入ることは構造上あり得ない。
+ * - マスターの項目名が選ばれた場合: isCustom=false に戻し、基準値をマスターから補完する（既存の挙動）。
+ */
+export function selectItemName(row: FormItemRow, value: string, masters: ItemMaster[]): FormItemRow {
+  if (value === CUSTOM_ITEM_OPTION_VALUE) {
+    return {
+      ...row,
+      isCustom: true,
+      item: recalcAbnormal({
+        ...row.item,
+        itemName: '',
+        unit: '',
+        referenceMin: null,
+        referenceMax: null,
+      }),
+    }
+  }
+
+  const item = { ...row.item, itemName: value }
+  const master = masters.find(m => m.itemName === value)
+  if (master) {
+    item.unit = master.unit
+    item.referenceMin = master.referenceMin
+    item.referenceMax = master.referenceMax
+  }
+  return { ...row, isCustom: false, item: recalcAbnormal(item) }
+}
+
+/** 直接入力欄（制御コンポーネント）の onChange 用。isCustom は変えず itemName だけを更新する。 */
+export function setCustomItemName(row: FormItemRow, value: string): FormItemRow {
+  return { ...row, item: recalcAbnormal({ ...row.item, itemName: value }) }
+}
+
+/** 項目名以外のフィールド（値・単位・基準値）更新用。既存の updateItem 相当。 */
+export function updateRowField(
+  row: FormItemRow,
+  field: Exclude<keyof ExaminationItem, 'itemName' | 'isAbnormal'>,
+  value: string,
+): FormItemRow {
+  const item = { ...row.item }
+  if (field === 'referenceMin' || field === 'referenceMax') {
+    item[field] = value === '' ? null : Number(value)
+  } else {
+    item[field] = value
+  }
+  return { ...row, item: recalcAbnormal(item) }
+}
+
+/**
+ * 保存対象の ExaminationItem[] へ変換する。
+ * 項目名が空（trim 後）の行は除外する（既存の挙動を維持）。
+ * selectItemName の実装により item.itemName に CUSTOM_ITEM_OPTION_VALUE が入ることはないが、
+ * 万一混入していたとしても trim() では空文字にならず除外されない点は仕様上の防御線として
+ * toSavableItemsRejectsCustomMarker のテストで別途保証する。
+ */
+export function toSavableItems(rows: FormItemRow[]): ExaminationItem[] {
+  return rows
+    .map(r => r.item)
+    .filter(i => i.itemName.trim() && i.itemName !== CUSTOM_ITEM_OPTION_VALUE)
+}

--- a/web/src/pages/RecordForm.tsx
+++ b/web/src/pages/RecordForm.tsx
@@ -1,14 +1,18 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { saveRecord, fetchMasters } from '../firestoreService'
-import type { ExaminationItem, ItemMaster } from '../types'
+import type { ItemMaster } from '../types'
+import {
+  CUSTOM_ITEM_OPTION_VALUE,
+  createEmptyRow,
+  selectItemName,
+  setCustomItemName,
+  toSavableItems,
+  updateRowField,
+  type FormItemRow,
+} from '../lib/recordFormRow'
 
 interface Props { uid: string }
-
-const emptyItem = (): ExaminationItem => ({
-  itemName: '', value: '', unit: '',
-  referenceMin: null, referenceMax: null, isAbnormal: false,
-})
 
 export default function RecordForm({ uid }: Props) {
   const navigate = useNavigate()
@@ -16,7 +20,11 @@ export default function RecordForm({ uid }: Props) {
 
   const [date, setDate] = useState(today)
   const [facility, setFacility] = useState('')
-  const [items, setItems] = useState<ExaminationItem[]>([emptyItem()])
+  // 行の識別には配列インデックスではなく安定した key を使う（Issue #51）。
+  // インデックスで直接入力モードを管理すると、行を削除したときにモードが別の行にずれてしまうため、
+  // 「直接入力モードかどうか」を行オブジェクト自身（FormItemRow.isCustom）に持たせている。
+  const nextKey = useRef(1)
+  const [rows, setRows] = useState<FormItemRow[]>([createEmptyRow('0')])
   const [masters, setMasters] = useState<ItemMaster[]>([])
   const [saving, setSaving] = useState(false)
 
@@ -24,48 +32,32 @@ export default function RecordForm({ uid }: Props) {
     fetchMasters(uid).then(setMasters)
   }, [uid])
 
-  const updateItem = (index: number, field: keyof ExaminationItem, value: string) => {
-    setItems(prev => {
-      const next = [...prev]
-      const item = { ...next[index] }
-
-      if (field === 'itemName') {
-        // 項目名選択時にマスターから基準値を自動補完
-        item.itemName = value
-        const master = masters.find(m => m.itemName === value)
-        if (master) {
-          item.unit = master.unit
-          item.referenceMin = master.referenceMin
-          item.referenceMax = master.referenceMax
-        }
-      } else if (field === 'referenceMin' || field === 'referenceMax') {
-        (item as Record<string, unknown>)[field] = value === '' ? null : Number(value)
-      } else {
-        (item as Record<string, unknown>)[field] = value
-      }
-
-      // isAbnormal を再計算
-      const num = parseFloat(item.value)
-      item.isAbnormal = !isNaN(num) && (
-        (item.referenceMin != null && num < item.referenceMin) ||
-        (item.referenceMax != null && num > item.referenceMax)
-      )
-
-      next[index] = item
-      return next
-    })
+  const updateRowAt = (index: number, updater: (row: FormItemRow) => FormItemRow) => {
+    setRows(prev => prev.map((row, i) => (i === index ? updater(row) : row)))
   }
 
-  const addItem = () => setItems(prev => [...prev, emptyItem()])
+  const handleItemNameSelect = (index: number, value: string) =>
+    updateRowAt(index, row => selectItemName(row, value, masters))
+
+  const handleCustomNameChange = (index: number, value: string) =>
+    updateRowAt(index, row => setCustomItemName(row, value))
+
+  const handleFieldChange = (index: number, field: 'value' | 'unit', value: string) =>
+    updateRowAt(index, row => updateRowField(row, field, value))
+
+  const addItem = () => {
+    const key = String(nextKey.current++)
+    setRows(prev => [...prev, createEmptyRow(key)])
+  }
   const removeItem = (index: number) =>
-    setItems(prev => prev.filter((_, i) => i !== index))
+    setRows(prev => prev.filter((_, i) => i !== index))
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!date) return
     setSaving(true)
     try {
-      const validItems = items.filter(i => i.itemName.trim())
+      const validItems = toSavableItems(rows)
       await saveRecord(uid, { date, facility, items: validItems })
       navigate('/')
     } finally {
@@ -105,49 +97,50 @@ export default function RecordForm({ uid }: Props) {
             </button>
           </div>
 
-          {items.map((item, i) => (
-            <div key={i} className={`item-row ${item.isAbnormal ? 'item-abnormal' : ''}`}>
+          {rows.map((row, i) => (
+            <div key={row.key} className={`item-row ${row.item.isAbnormal ? 'item-abnormal' : ''}`}>
               <div className="item-fields">
                 <div className="item-field-name">
                   {masters.length > 0 ? (
                     <select
-                      value={item.itemName}
-                      onChange={e => updateItem(i, 'itemName', e.target.value)}
+                      value={row.isCustom ? CUSTOM_ITEM_OPTION_VALUE : row.item.itemName}
+                      onChange={e => handleItemNameSelect(i, e.target.value)}
                     >
                       <option value="">項目を選択</option>
                       {masters.map(m => (
                         <option key={m.itemName} value={m.itemName}>{m.itemName}</option>
                       ))}
-                      <option value="__custom__">直接入力</option>
+                      <option value={CUSTOM_ITEM_OPTION_VALUE}>直接入力</option>
                     </select>
                   ) : (
                     <input
                       type="text"
-                      value={item.itemName}
-                      onChange={e => updateItem(i, 'itemName', e.target.value)}
+                      value={row.item.itemName}
+                      onChange={e => handleCustomNameChange(i, e.target.value)}
                       placeholder="項目名"
                     />
                   )}
-                  {item.itemName === '__custom__' && (
+                  {row.isCustom && (
                     <input
                       type="text"
+                      value={row.item.itemName}
                       placeholder="項目名を入力"
-                      onChange={e => updateItem(i, 'itemName', e.target.value)}
+                      onChange={e => handleCustomNameChange(i, e.target.value)}
                       className="custom-name"
                     />
                   )}
                 </div>
                 <input
                   type="text"
-                  value={item.value}
-                  onChange={e => updateItem(i, 'value', e.target.value)}
+                  value={row.item.value}
+                  onChange={e => handleFieldChange(i, 'value', e.target.value)}
                   placeholder="値"
                   className="item-field-value"
                 />
                 <input
                   type="text"
-                  value={item.unit}
-                  onChange={e => updateItem(i, 'unit', e.target.value)}
+                  value={row.item.unit}
+                  onChange={e => handleFieldChange(i, 'unit', e.target.value)}
                   placeholder="単位"
                   className="item-field-unit"
                 />
@@ -156,7 +149,7 @@ export default function RecordForm({ uid }: Props) {
                 type="button"
                 className="btn-remove"
                 onClick={() => removeItem(i)}
-                disabled={items.length === 1}
+                disabled={rows.length === 1}
               >
                 ✕
               </button>


### PR DESCRIPTION
Closes #51

## 背景・不具合

Web版の記録入力フォームで、検査項目マスターが1件以上ある状態（＝Androidと同期済みの実運用状態）で「直接入力」を選ぶと、以下の2つの不具合があった。

1. 直接入力欄の表示条件が `item.itemName === '__custom__'` だったため、1文字入力した瞬間に `item.itemName` が変わり条件が false になって入力欄自体がアンマウントされ、複数文字を入力できなかった（`<input>` が非制御コンポーネントだったため、再表示しても入力途中の文字は復元されない）。
2. `'__custom__'` という一時的な選択値がそのまま `item.itemName` に格納される構造だったため、直接入力欄に何も入力せず保存すると `__custom__` という項目名の検査項目が Firestore に保存され、Android側にも同期されてしまう。

## 実装内容

「直接入力を選んでいる」という UI 状態を、項目名フィールドとは独立に保持する構造に変更した。

- 状態遷移ロジックを `web/src/lib/recordFormRow.ts` に純関数として切り出した
  - `FormItemRow { key, item, isCustom }` という型を導入し、`isCustom`（直接入力モードかどうか）を `item.itemName` とは別に、行オブジェクト自身に持たせた
  - `selectItemName()`: `__custom__` が選ばれた時点で `isCustom=true` にし、`itemName` は空文字にリセットする（マスター選択時に補完されていた `unit`/`referenceMin`/`referenceMax` もリセットする。LDLなど他の項目の単位・基準値をそのまま直接入力項目に引き継がないための意図的な変更）。これにより `'__custom__'` が `item.itemName` に入ること自体が構造上あり得ない
  - `setCustomItemName()`: 直接入力欄の `onChange` 用。`isCustom` は変えず `itemName` のみを更新する
  - `toSavableItems()`: 項目名が空（trim後）の行を除外する既存の挙動を維持。加えて `CUSTOM_ITEM_OPTION_VALUE`（`'__custom__'`）そのものが紛れ込んだ場合も除外する防御的フィルタを追加（構造上は発生し得ないが、保存経路側でも二重に保証する形にした）
- `web/src/pages/RecordForm.tsx` を上記の純関数を使う形に書き換えた
  - 直接入力欄を `value={row.item.itemName}` の**制御コンポーネント**にし、入力途中の値が保持されるようにした
  - `<select>` の `value` は `row.isCustom ? CUSTOM_ITEM_OPTION_VALUE : row.item.itemName` とし、直接入力モード中は常に「直接入力」が選択された状態を維持する

### 状態の持ち方（行の追加・削除で壊れないことの担保）

`isCustom` フラグは配列のインデックスやインデックスの集合（`Set<number>`）ではなく、**各行オブジェクト自身**（`FormItemRow.isCustom`）に持たせた。

- `removeItem` は従来どおり配列インデックスでフィルタするが、削除されるのは行オブジェクトそのものであり、`isCustom` はその行オブジェクトに紐づいているため、削除後に残る行の `isCustom` が別の行にずれることは構造上あり得ない
- 行の識別・React の `key` にも、配列インデックス（`key={i}`）ではなく行追加時に採番する安定した `key`（`FormItemRow.key`、`useRef` のカウンタで採番）を使うようにした
- `web/src/lib/recordFormRow.test.ts` に「先頭の行を削除しても残りの行が自分の `key` に紐づく `isCustom` を保つ」ことを検証するテストを追加した

## テスト方針（新規依存を追加するかどうかの判断）

**新しいテスト依存（React Testing Library 等）は追加していない。**

理由: 今回の不具合の本質は「UIコンポーネントのレンダリング結果」ではなく「状態遷移のロジック」（`__custom__` を選んだときにどう状態が変わるか、複数文字入力してもモードが保たれるか、削除・追加でずれないか）にある。このロジックを `web/src/lib/recordFormRow.ts` に純関数として切り出すことで、既存の `lib/trend.ts` / `lib/abnormal.ts` / `lib/recalcAbnormal.ts` と同じ流儀（`web/src/lib/*.test.ts` で vitest によるユニットテスト）に沿ってテストできた。コンポーネントのレンダリングテストが必須になるほどの複雑さ（DOMイベントの発火順序に強く依存する挙動など）はなかったため、依存を増やさない方針にした。

`web/src/lib/recordFormRow.test.ts` に18件のテストケースを追加し、以下を検証している。
- 「直接入力」選択時に `isCustom=true` になり `itemName` が空文字にリセットされること、`CUSTOM_ITEM_OPTION_VALUE` が `itemName` に入らないこと
- マスター選択時に `isCustom=false` に戻り、基準値・単位が補完されること
- 直接入力欄で1文字ずつ・複数文字（「随時血糖」）を最後まで入力しても `isCustom` が保たれ、`itemName` が正しく更新されること
- 保存対象への変換（`toSavableItems`）で、直接入力した項目名がそのまま保存されること／何も入力しなかった行が除外されること／`CUSTOM_ITEM_OPTION_VALUE` が万一混入していても除外されること／マスター選択行と直接入力行が混在しても正しく保存されること
- 行の追加・削除で `isCustom` が他の行にずれないこと

## 未解決の質問への暫定回答

Issue本文の「❓未解決の質問」（直接入力した項目名をマスターにも自動登録すべきか、Android側 S-06a の挙動に合わせるべきか）については、**今回のスコープには含めていない**。

本Issueの主題は「直接入力ができない不具合の修正」であり、マスターへの自動登録は挙動の追加にあたる。Android側の仕様確認も必要になりスコープが広がるため、既定どおり見送った。マスター自動登録が必要な場合は別Issueで扱うのが適切と考える。

## テスト結果

- `npm --prefix web run test -- --run`: 71 tests passed（うち新規18件）
- `npm --prefix web run lint`: 0 errors（`ItemMasters.tsx` の既存の warning 1件は今回の変更と無関係、未着手のまま）
- `npm --prefix web run build`: 成功（`tsc -b && vite build`）

## 未確認事項

**実ブラウザでの動作確認はできていません。** この不具合はFirestore側に検査項目マスターが1件以上ある状態（＝Firebase認証を通した実データ環境）でのみ再現するため、この環境からは検証できませんでした。そのため以下は未確認です。

- 実ブラウザで「直接入力」を選び、複数文字の項目名（例「随時血糖」）を最後まで入力できること
- 保存した記録がFirestoreに正しく保存され、Web/Androidの記録詳細で正しく表示されること（受け入れ基準の2番目）

上記はロジックを純関数として切り出したユニットテスト（`recordFormRow.test.ts`）でカバーしていますが、実際のブラウザ操作・Firestore保存・Android側での表示確認は行っていません。

## 禁止事項として避けたこと

- 項目マスターへの自動登録は実装していません
- 既存のフォーム項目の追加・削除は行っていません
- 配色・レイアウトの変更、カラーコードの直書きは行っていません
- スコープを超えたリファクタリングは行わず、`RecordForm.tsx` の該当箇所のみを変更しています
