### PR TITLE
Android端末2台使用時のFirestore記録ID衝突を修正（remoteId/UUID方式へ）

### DIFF
--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/HealthCheckupDatabase.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/HealthCheckupDatabase.kt
@@ -16,7 +16,7 @@ import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
 
 @Database(
     entities = [ExaminationRecord::class, ExaminationItem::class, ItemMaster::class],
-    version = 3
+    version = 4
 )
 abstract class HealthCheckupDatabase : RoomDatabase() {
     abstract fun recordDao(): ExaminationRecordDao
@@ -123,6 +123,43 @@ abstract class HealthCheckupDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v3→v4（Issue #49）: examination_records に、Firestoreドキュメント ID として使う
+         * グローバルに一意な [ExaminationRecord.remoteId] を追加する。
+         *
+         * 背景: これまで Firestore のドキュメント ID には Room の AUTOINCREMENT 連番
+         * （[ExaminationRecord.id] の文字列表現）をそのまま使っていた。この連番は端末ローカルの
+         * 採番空間のため、同じ Google アカウントで Android 端末を2台使うと、両方の端末が
+         * 独立に同じ番号（例: id=2）を採番し得る。その結果 Firestore 上で同じドキュメント ID に
+         * 書き込みが競合し、`set()`（mergeなし）により片方の健診記録が完全に上書きされ消失する
+         * （Issue #49 本文の再現シナリオ）。
+         *
+         * 対応方針（Issue #49「未解決の質問」への回答・共存方式を採用）:
+         * - 既存の数値IDドキュメントを新IDへ書き換える一括移行は行わない。
+         *   Firestore上の全記録を読み直して新IDで書き直し旧IDを削除する操作は、
+         *   健診データという機微データに対して途中失敗時の復旧が困難なため。
+         * - 代わりに、既存行の [ExaminationRecord.remoteId] には現在の [ExaminationRecord.id] の
+         *   文字列表現をそのまま入れる。これにより既存のFirestoreドキュメントとの対応
+         *   （ドキュメントID＝移行前のid.toString()）は変更後も壊れない。
+         * - 新規作成される記録のみ、Kotlin側のデフォルト値（UUID.randomUUID()）により
+         *   グローバルに一意なIDが採番される（[FirestoreRepository.saveRecord] 参照）。
+         * - この結果、Firestore上のドキュメントIDは「数値ID（移行前からの既存記録）」と
+         *   「UUID（移行後の新規記録）」の2形式が混在するが、[remoteId] をキーにすれば
+         *   Android側の読み出し・突き合わせは形式によらず統一的に扱える。
+         *
+         * UNIQUE インデックスを付与し、同一端末内で remoteId が重複しないことをDBレベルでも担保する。
+         */
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE examination_records ADD COLUMN remoteId TEXT NOT NULL DEFAULT ''")
+                db.execSQL("UPDATE examination_records SET remoteId = CAST(id AS TEXT)")
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS index_examination_records_remoteId " +
+                        "ON examination_records(remoteId)"
+                )
+            }
+        }
+
         private val PREPOPULATE_CALLBACK = object : RoomDatabase.Callback() {
             override fun onCreate(db: SupportSQLiteDatabase) {
                 super.onCreate(db)
@@ -147,7 +184,7 @@ abstract class HealthCheckupDatabase : RoomDatabase() {
                     "health_checkup.db"
                 )
                     .addCallback(PREPOPULATE_CALLBACK)
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                     .build().also { INSTANCE = it }
             }
         }

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/dao/ExaminationRecordDao.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/dao/ExaminationRecordDao.kt
@@ -3,8 +3,8 @@ package com.rokusoudo.healthcheckup.data.db.dao
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
-import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Update
 import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
 import kotlinx.coroutines.flow.Flow
 
@@ -14,9 +14,12 @@ interface ExaminationRecordDao {
     @Insert
     suspend fun insert(record: ExaminationRecord): Long
 
-    /** Firestore復元時に既存レコードをIDで上書きする */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun upsert(record: ExaminationRecord): Long
+    /**
+     * Issue #49: restoreFromFirestore() で remoteId をキーに既存の端末ローカル記録を
+     * 更新する（端末ローカルの id はそのまま維持する）。
+     */
+    @Update
+    suspend fun update(record: ExaminationRecord)
 
     @Delete
     suspend fun delete(record: ExaminationRecord)
@@ -27,19 +30,30 @@ interface ExaminationRecordDao {
     @Query("SELECT * FROM examination_records WHERE id = :id")
     suspend fun getById(id: Long): ExaminationRecord?
 
+    /**
+     * Issue #49: Firestoreドキュメント ID（[ExaminationRecord.remoteId]）をキーに
+     * 端末ローカルの記録を検索する。restoreFromFirestore() の upsert 判定に使う
+     * （端末ローカルの [ExaminationRecord.id] は端末ごとに異なり得るため、これで突き合わせる）。
+     */
+    @Query("SELECT * FROM examination_records WHERE remoteId = :remoteId")
+    suspend fun getByRemoteId(remoteId: String): ExaminationRecord?
+
     /** Issue #46: Firestoreへのpushが成功した記録に確認フラグを立てる。 */
     @Query("UPDATE examination_records SET pushedToFirestore = 1 WHERE id = :id")
     suspend fun markPushed(id: Long)
 
     /**
      * Issue #46: 差分ミラー削除。push済み（pushedToFirestore = 1）かつ、
-     * 直近の restoreFromFirestore の fetch 結果（[keepIds]）に含まれない
+     * 直近の restoreFromFirestore の fetch 結果（[keepRemoteIds]）に含まれない
      * ＝Firestore側で削除された記録を Room からも削除する。
      * push未確認（オフライン保存直後等）の記録は対象外のため誤って消えない。
      * 削除は examination_items へ ON DELETE CASCADE で伝播する。
+     *
+     * Issue #49: 端末ローカルの [ExaminationRecord.id] は端末間で衝突し得るため、
+     * 判定キーは Firestore ドキュメント ID である [ExaminationRecord.remoteId] を用いる。
      */
-    @Query("DELETE FROM examination_records WHERE pushedToFirestore = 1 AND id NOT IN (:keepIds)")
-    suspend fun deleteMirrored(keepIds: List<Long>)
+    @Query("DELETE FROM examination_records WHERE pushedToFirestore = 1 AND remoteId NOT IN (:keepRemoteIds)")
+    suspend fun deleteMirrored(keepRemoteIds: List<String>)
 
     /**
      * Issue #34: アカウント削除機能用。端末内の全診断記録を削除する。

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/entity/ExaminationRecord.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/db/entity/ExaminationRecord.kt
@@ -2,13 +2,18 @@ package com.rokusoudo.healthcheckup.data.db.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * 診断記録（ヘッダー）エンティティ。
  * 1回の健康診断を表す。
  */
-@Entity(tableName = "examination_records")
+@Entity(
+    tableName = "examination_records",
+    indices = [Index(value = ["remoteId"], unique = true)]
+)
 data class ExaminationRecord(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val date: String,       // "yyyy-MM-dd" 形式
@@ -23,5 +28,19 @@ data class ExaminationRecord(
      * オフライン保存直後などpush未確認のローカル記録を誤って消さないようにする。
      */
     @ColumnInfo(defaultValue = "0")
-    val pushedToFirestore: Boolean = false
+    val pushedToFirestore: Boolean = false,
+    /**
+     * Issue #49: Firestoreのドキュメント ID として使うグローバルに一意な ID（UUID v4）。
+     * Room の [id] は端末ローカルのAUTOINCREMENT連番のため、同じアカウントで複数端末を使うと
+     * 端末間で番号が衝突し、Firestore 上のドキュメントが上書きされ合って記録が消える不具合があった。
+     * [remoteId] を Firestore ドキュメント ID・端末間の同一記録の突き合わせキーにすることで、
+     * Room の [id] はあくまで端末ローカルの主キーとして自由に採番できるようにする。
+     *
+     * デフォルト値はKotlin側でランダムなUUIDを生成する（新規作成時に呼び出し側が明示的に
+     * 指定しなくても一意性が保たれる）。Room移行（v3→v4）で追加された既存行には、
+     * 既存のFirestoreドキュメントとの対応を壊さないよう [id] の文字列表現がそのまま入る
+     * （[HealthCheckupDatabase.MIGRATION_3_4] 参照）。
+     */
+    @ColumnInfo(defaultValue = "")
+    val remoteId: String = UUID.randomUUID().toString()
 )

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/FirestoreRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/FirestoreRepository.kt
@@ -13,8 +13,13 @@ import kotlinx.coroutines.withTimeout
 
 /**
  * Cloud Firestore との読み書きを担当する Repository。
- * データパス: users/{uid}/records/{roomId}
+ * データパス: users/{uid}/records/{remoteId}
  *             users/{uid}/itemMasters/{itemName}
+ *
+ * Issue #49: records のドキュメント ID は端末ローカルの Room id ではなく
+ * [ExaminationRecord.remoteId]（グローバルに一意な UUID）を使う。
+ * 既存の数値IDドキュメント（移行前に作成された記録）とは共存し、一括移行はしない
+ * （詳細は [com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase.MIGRATION_3_4] 参照）。
  *
  * 薬事法対応: 保存・取得はデータの表示目的のみ。医療診断に使用しない。
  */
@@ -30,7 +35,8 @@ class FirestoreRepository : HealthCloudSync {
 
     /**
      * 診断記録をFirestoreに保存する。
-     * ドキュメントID = Room の recordId（文字列）でクロスプラットフォーム同期を担保。
+     * ドキュメントID = [ExaminationRecord.remoteId]（UUID。Issue #49でRoomのローカルidから変更）。
+     * これによりRoomのidが端末間で衝突しても、Firestore上のドキュメントは衝突しない。
      */
     override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
         val data = mapOf(
@@ -48,7 +54,7 @@ class FirestoreRepository : HealthCloudSync {
                 )
             }
         )
-        recordsRef(uid).document(record.id.toString()).set(data).await()
+        recordsRef(uid).document(record.remoteId).set(data).await()
     }
 
     /**
@@ -70,22 +76,39 @@ class FirestoreRepository : HealthCloudSync {
 
     /**
      * Firestoreから全診断記録を取得する（他端末データ復元用）。
+     *
+     * Issue #49: ドキュメントID（[ExaminationRecord.remoteId]）は数値ID（移行前の既存記録）と
+     * UUID（移行後の新規記録）の2形式が混在し得るため、[doc.id] を Long に変換できない
+     * ドキュメントを黙って捨てていた従来の実装（`doc.id.toLongOrNull() ?: return@mapNotNull null`）
+     * を廃止した。この判定を残したままUUIDを導入すると、新形式のドキュメントが
+     * fetchRecords() の結果から全て消え、restoreFromFirestore() の差分ミラー削除により
+     * 他端末で保存した新形式の記録がRoomから誤って削除されてしまう。
+     *
+     * 返却する [ExaminationRecord.id] は端末ローカルの主キーであり、Firestore側には存在しない情報
+     * のため 0（未確定）を設定する。実際のローカルidは呼び出し元（HealthRepository.restoreFromFirestore）が
+     * [ExaminationRecord.remoteId] をキーに端末ローカルの既存行と突き合わせたうえで確定する。
+     * 同様に [ExaminationItem.recordId] もこの時点では確定しないため 0 を設定する。
      */
     override suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> {
         val snapshot = recordsRef(uid).get().await()
         return snapshot.documents.mapNotNull { doc ->
-            val id = doc.id.toLongOrNull() ?: return@mapNotNull null
             val date = doc.getString("date") ?: return@mapNotNull null
             val facility = doc.getString("facility") ?: ""
             val createdAt = doc.getLong("createdAt") ?: System.currentTimeMillis()
-            val record = ExaminationRecord(id = id, date = date, facility = facility, createdAt = createdAt)
+            val record = ExaminationRecord(
+                id = 0,
+                date = date,
+                facility = facility,
+                createdAt = createdAt,
+                remoteId = doc.id
+            )
 
             @Suppress("UNCHECKED_CAST")
             val itemsData = doc.get("items") as? List<Map<String, Any?>> ?: emptyList()
             val items = itemsData.map { map ->
                 ExaminationItem(
                     id = 0,
-                    recordId = id,
+                    recordId = 0,
                     itemName = map["itemName"] as? String ?: "",
                     value = map["value"] as? String ?: "",
                     unit = map["unit"] as? String ?: "",
@@ -100,7 +123,8 @@ class FirestoreRepository : HealthCloudSync {
 
     /**
      * Issue #47: 診断記録を1件、Firestoreから削除する。
-     * ドキュメントID = Room の recordId（文字列）。失敗時は例外を呼び出し元へ伝播する。
+     * ドキュメントID = [ExaminationRecord.remoteId]（Issue #49でRoomのローカルidから変更）。
+     * 失敗時は例外を呼び出し元へ伝播する。
      *
      * Firestore SDK はデフォルトでオフライン永続化が有効なため、オフライン時の
      * delete().await() はネットワーク復帰まで完了しない（すぐには例外を投げない）。
@@ -111,9 +135,9 @@ class FirestoreRepository : HealthCloudSync {
      * HealthRepository側のcatchに流す。タイムアウト後もSDKに削除自体はキューされ得るが、
      * その場合はIssue #46（方式A）の次回restoreFromFirestoreの差分ミラー削除がRoom側を追従させる。
      */
-    override suspend fun deleteRecord(uid: String, recordId: Long) {
+    override suspend fun deleteRecord(uid: String, remoteId: String) {
         withTimeout(DELETE_TIMEOUT_MS) {
-            recordsRef(uid).document(recordId.toString()).delete().await()
+            recordsRef(uid).document(remoteId).delete().await()
         }
     }
 

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthCloudSync.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthCloudSync.kt
@@ -18,8 +18,11 @@ interface HealthCloudSync {
      * Issue #47: 診断記録を1件、Firestoreから削除する。
      * 失敗時は例外をそのまま呼び出し元（HealthRepository.deleteRecord）へ伝播させる
      * （オフライン時などに握りつぶすと Room だけ削除されFirestore側に残り続けるため）。
+     *
+     * Issue #49: 引数はRoomのローカルidではなく、Firestoreドキュメント ID である
+     * [com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord.remoteId] を渡すこと。
      */
-    suspend fun deleteRecord(uid: String, recordId: Long)
+    suspend fun deleteRecord(uid: String, remoteId: String)
 
     /**
      * Issue #34: アカウント削除機能用。

--- a/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
+++ b/android/app/src/main/java/com/rokusoudo/healthcheckup/data/repository/HealthRepository.kt
@@ -182,9 +182,13 @@ class HealthRepository(
      */
     suspend fun deleteRecord(recordId: Long): Result<Unit> {
         val uid = currentUidProvider()
-        if (uid != null) {
+        // Issue #49: FirestoreドキュメントIDはremoteId。削除対象の記録が既にRoomに無い場合は
+        // remoteIdを解決できないため、Firestore側の削除は試みずローカルの削除のみ行う
+        // （元々存在しないIDへの呼び出しなので、下のトランザクションもno-opで成功する）。
+        val record = db.recordDao().getById(recordId)
+        if (uid != null && record != null) {
             try {
-                firestoreRepository.deleteRecord(uid, recordId)
+                firestoreRepository.deleteRecord(uid, record.remoteId)
             } catch (e: Exception) {
                 return Result.failure(e)
             }
@@ -254,12 +258,29 @@ class HealthRepository(
         }
 
         // 診断記録を復元。Firestoreのfetchで確認できた時点でpush済みとみなしフラグを立てる
+        //
+        // Issue #49: 端末ローカルの ExaminationRecord.id は端末ごとに独立して採番されるため、
+        // 複数端末間で同じ id が別々の記録を指し得る。そのため upsert の突き合わせキーには
+        // Firestoreドキュメント ID である remoteId を使う（端末ローカルの id ではない）。
+        // - remoteId に一致する行が既にRoomにあれば、その行の端末ローカル id を維持したまま内容を更新する
+        //   （id を上書きすると、他の外部キー参照や端末ローカルの識別が壊れるため）。
+        // - なければ新規行として挿入し、Room に端末ローカルの id を新規採番させる
+        //   （Firestore側のドキュメントIDをそのままRoomのidに使うと、旧方式と同じ端末間衝突を
+        //   再現しかねないため、意図的に別空間として扱う）。
         for ((record, items) in records) {
-            db.recordDao().upsert(record.copy(pushedToFirestore = true))
-            db.itemDao().deleteByRecordId(record.id)
-            db.itemDao().insertAll(items)
+            val existing = db.recordDao().getByRemoteId(record.remoteId)
+            val localId = if (existing != null) {
+                db.recordDao().update(record.copy(id = existing.id, pushedToFirestore = true))
+                existing.id
+            } else {
+                db.recordDao().insert(record.copy(id = 0, pushedToFirestore = true))
+            }
+            db.itemDao().deleteByRecordId(localId)
+            db.itemDao().insertAll(items.map { it.copy(recordId = localId) })
         }
-        db.recordDao().deleteMirrored(records.map { it.first.id })
+        // Issue #49: 差分ミラー削除もremoteIdキーで判定する（端末ローカルidでは他端末の記録と
+        // 衝突しうるため、「Firestore側に存在するか」を正しく判定できない）。
+        db.recordDao().deleteMirrored(records.map { it.first.remoteId })
 
         // 項目マスターを復元。記録と同様にfetchで確認できたものはpush済み扱いにする
         for (master in masters) {

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/account/AccountDeletionManagerTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/account/AccountDeletionManagerTest.kt
@@ -209,7 +209,7 @@ class AccountDeletionManagerTest {
             callLog.add("cloud" to System.nanoTime())
         }
 
-        override suspend fun deleteRecord(uid: String, recordId: Long) {
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
             // 本テストでは未使用（Issue #47）
         }
     }

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/db/MigrationTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/db/MigrationTest.kt
@@ -68,7 +68,11 @@ class MigrationTest {
         createV1Database(context)
 
         val room = Room.databaseBuilder(context, HealthCheckupDatabase::class.java, dbName)
-            .addMigrations(HealthCheckupDatabase.MIGRATION_1_2, HealthCheckupDatabase.MIGRATION_2_3)
+            .addMigrations(
+                HealthCheckupDatabase.MIGRATION_1_2,
+                HealthCheckupDatabase.MIGRATION_2_3,
+                HealthCheckupDatabase.MIGRATION_3_4
+            )
             .allowMainThreadQueries()
             .build()
         try {
@@ -147,7 +151,7 @@ class MigrationTest {
         createV2Database(context)
 
         val room = Room.databaseBuilder(context, HealthCheckupDatabase::class.java, dbName)
-            .addMigrations(HealthCheckupDatabase.MIGRATION_2_3)
+            .addMigrations(HealthCheckupDatabase.MIGRATION_2_3, HealthCheckupDatabase.MIGRATION_3_4)
             .allowMainThreadQueries()
             .build()
         try {
@@ -163,6 +167,87 @@ class MigrationTest {
                 assertEquals("2025-06-01", record.date)
                 assertEquals(false, record.pushedToFirestore)
                 assertEquals(1, room.itemDao().getByRecordIdOnce(1L).size)
+            }
+        } finally {
+            room.close()
+            context.deleteDatabase(dbName)
+        }
+    }
+
+    /** Room v3 が生成していたスキーマを再現する（pushedToFirestore追加済み、remoteId はまだ無い） */
+    private fun createV3Database(context: Context) {
+        context.deleteDatabase(dbName)
+        val dbFile = context.getDatabasePath(dbName)
+        dbFile.parentFile?.mkdirs()
+        val db = SQLiteDatabase.openOrCreateDatabase(dbFile, null)
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `examination_records` " +
+                "(`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `date` TEXT NOT NULL, " +
+                "`facility` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, " +
+                "`pushedToFirestore` INTEGER NOT NULL DEFAULT 0)"
+        )
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `examination_items` " +
+                "(`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `recordId` INTEGER NOT NULL, " +
+                "`itemName` TEXT NOT NULL, `value` TEXT NOT NULL, `unit` TEXT NOT NULL, " +
+                "`referenceMin` REAL, `referenceMax` REAL, `isAbnormal` INTEGER NOT NULL, " +
+                "FOREIGN KEY(`recordId`) REFERENCES `examination_records`(`id`) " +
+                "ON UPDATE NO ACTION ON DELETE CASCADE)"
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_examination_items_recordId` ON `examination_items` (`recordId`)")
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `item_masters` " +
+                "(`itemName` TEXT NOT NULL, `unit` TEXT NOT NULL, `referenceMin` REAL, `referenceMax` REAL, " +
+                "`category` TEXT NOT NULL DEFAULT 'その他', `isFavorite` INTEGER NOT NULL DEFAULT 0, " +
+                "`favoritedAt` INTEGER, `pushedToFirestore` INTEGER NOT NULL DEFAULT 0, " +
+                "PRIMARY KEY(`itemName`))"
+        )
+        // v3時代（Issue #49移行前）に保存済みの記録。Firestoreのドキュメント ID はこのRoom idの
+        // 文字列表現がそのまま使われていた（FirestoreRepository.saveRecord の旧実装）。
+        db.execSQL(
+            "INSERT INTO examination_records (id, date, facility, createdAt, pushedToFirestore) " +
+                "VALUES (7, '2025-06-01', 'テスト病院', 1000, 1)"
+        )
+        db.execSQL(
+            "INSERT INTO examination_items (recordId, itemName, value, unit, referenceMin, referenceMax, isAbnormal) " +
+                "VALUES (7, 'LDLコレステロール', '150', 'mg/dL', NULL, 139.0, 1)"
+        )
+        db.version = 3
+        db.close()
+    }
+
+    /**
+     * Room v3→v4 Migration のテスト（Issue #49）。
+     *
+     * - remoteId カラムが追加されること
+     * - 既存行（移行前に作成された記録）には remoteId として id の文字列表現がそのまま入り、
+     *   既存のFirestoreドキュメントとの対応が壊れないこと（一括移行はしない共存方式）
+     * - 既存データ（診断記録・検査項目）自体は一切失われないこと
+     */
+    @Test
+    fun `v3からv4への移行で既存行のremoteIdにはidの文字列表現が入る`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        createV3Database(context)
+
+        val room = Room.databaseBuilder(context, HealthCheckupDatabase::class.java, dbName)
+            .addMigrations(HealthCheckupDatabase.MIGRATION_3_4)
+            .allowMainThreadQueries()
+            .build()
+        try {
+            runBlocking {
+                val record = room.recordDao().getById(7L)!!
+                assertEquals("2025-06-01", record.date)
+                // Issue #49: 既存行のremoteIdには、移行前のFirestoreドキュメントID
+                // （Roomのid.toString()）がそのまま入り、既存ドキュメントとの対応を壊さない
+                assertEquals("7", record.remoteId)
+                assertEquals(true, record.pushedToFirestore)
+
+                // remoteIdキーでも同じ行が引けること（restoreFromFirestoreの突き合わせに使う）
+                val byRemoteId = room.recordDao().getByRemoteId("7")
+                assertEquals(7L, byRemoteId!!.id)
+
+                // 既存データ自体は失われない
+                assertEquals(1, room.itemDao().getByRecordIdOnce(7L).size)
             }
         } finally {
             room.close()

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryDeleteTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryDeleteTest.kt
@@ -83,6 +83,7 @@ class HealthRepositoryDeleteTest {
     @Test
     fun `Firestore削除が成功すると記録と検査項目がRoomから削除される`() = runBlocking {
         val recordId = insertRecordWithItems()
+        val remoteId = db.recordDao().getById(recordId)!!.remoteId
         val repository = HealthRepository(db, cloudSync, currentUidProvider = { "test-uid" })
 
         val result = repository.deleteRecord(recordId)
@@ -91,7 +92,8 @@ class HealthRepositoryDeleteTest {
         assertNull(db.recordDao().getById(recordId))
         // 孤児レコードが残らないこと（examination_items）
         assertTrue(db.itemDao().getByRecordIdOnce(recordId).isEmpty())
-        assertEquals(listOf(recordId), cloudSync.deletedRecordIds)
+        // Issue #49: Firestoreへの削除呼び出しはRoomのローカルidではなくremoteId（ドキュメントID）で行われる
+        assertEquals(listOf(remoteId), cloudSync.deletedRemoteIds)
     }
 
     @Test
@@ -119,7 +121,7 @@ class HealthRepositoryDeleteTest {
 
         assertTrue(result.isSuccess)
         assertNull(db.recordDao().getById(recordId))
-        assertTrue(cloudSync.deletedRecordIds.isEmpty())
+        assertTrue(cloudSync.deletedRemoteIds.isEmpty())
     }
 
     @Test
@@ -146,7 +148,7 @@ class HealthRepositoryDeleteTest {
 
     private class FakeHealthCloudSync : HealthCloudSync {
         var shouldThrowOnDelete: Boolean = false
-        val deletedRecordIds = mutableListOf<Long>()
+        val deletedRemoteIds = mutableListOf<String>()
 
         override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
             // 本テストでは未使用
@@ -161,9 +163,9 @@ class HealthRepositoryDeleteTest {
 
         override suspend fun fetchItemMasters(uid: String): List<ItemMaster> = emptyList()
 
-        override suspend fun deleteRecord(uid: String, recordId: Long) {
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
             if (shouldThrowOnDelete) throw RuntimeException("Firestore unavailable")
-            deletedRecordIds.add(recordId)
+            deletedRemoteIds.add(remoteId)
         }
 
         override suspend fun deleteAllUserData(uid: String) {

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryMirrorDeleteTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryMirrorDeleteTest.kt
@@ -242,7 +242,7 @@ class HealthRepositoryMirrorDeleteTest {
             // Issue #46 のミラー削除テストの対象外（Issue #34 のアカウント削除専用メソッド）
         }
 
-        override suspend fun deleteRecord(uid: String, recordId: Long) {
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
             // Issue #46 のミラー削除テストの対象外（Issue #47 の記録1件削除専用メソッド）
         }
     }

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryRecalcTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryRecalcTest.kt
@@ -196,7 +196,7 @@ class HealthRepositoryRecalcTest {
 
         override suspend fun fetchItemMasters(uid: String): List<ItemMaster> = emptyList()
 
-        override suspend fun deleteRecord(uid: String, recordId: Long) {
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
             // 本テストでは未使用（Issue #47）
         }
 

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryRemoteIdSyncTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryRemoteIdSyncTest.kt
@@ -1,0 +1,201 @@
+package com.rokusoudo.healthcheckup.data.repository
+
+import android.app.Application
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rokusoudo.healthcheckup.data.db.HealthCheckupDatabase
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationItem
+import com.rokusoudo.healthcheckup.data.db.entity.ExaminationRecord
+import com.rokusoudo.healthcheckup.data.db.entity.ItemMaster
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #49: Firestoreの記録ドキュメントIDを端末ローカルの連番からremoteId（UUID）へ切り替えたことを検証する。
+ *
+ * - restoreFromFirestore() がremoteIdをキーに突き合わせ、同じ記録が二重にRoomへ入らないこと
+ * - 2台の端末がそれぞれ端末ローカル採番id=2の記録を作っても、Firestore上（＝共有のHealthCloudSync）では
+ *   別ドキュメントとして扱われ、互いを上書きしないこと（本Issueが修正する不具合そのものの回帰テスト）
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class HealthRepositoryRemoteIdSyncTest {
+
+    private lateinit var db: HealthCheckupDatabase
+    private lateinit var cloudSync: FakeSharedFirestore
+    private lateinit var repository: HealthRepository
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            HealthCheckupDatabase::class.java
+        ).allowMainThreadQueries().build()
+        cloudSync = FakeSharedFirestore()
+        repository = HealthRepository(db, cloudSync, currentUidProvider = { "shared-uid" })
+    }
+
+    @After
+    fun teardown() {
+        db.close()
+    }
+
+    @Test
+    fun `restoreFromFirestoreはremoteIdをキーに突き合わせ同じ記録を二重にRoomへ入れない`() = runBlocking {
+        val remoteId = "web-uuid-1"
+        cloudSync.recordsToReturn = listOf(
+            ExaminationRecord(id = 0, date = "2026-08-01", facility = "Web入力", createdAt = 1000L, remoteId = remoteId) to
+                listOf(
+                    ExaminationItem(
+                        recordId = 0,
+                        itemName = "LDL",
+                        value = "150",
+                        unit = "mg/dL",
+                        referenceMin = null,
+                        referenceMax = 139.0,
+                        isAbnormal = true
+                    )
+                )
+        )
+
+        // 同じfetch結果で2回連続復元しても重複行が作られないこと（アプリ起動のたびに再同期されるため）
+        repository.restoreFromFirestore("shared-uid")
+        repository.restoreFromFirestore("shared-uid")
+
+        val all = db.recordDao().getAll().first()
+        assertEquals(1, all.size)
+        assertEquals(remoteId, all[0].remoteId)
+        assertEquals(1, db.itemDao().getByRecordIdOnce(all[0].id).size)
+    }
+
+    @Test
+    fun `remoteIdが一致する既存ローカル記録は端末ローカルidを保ったまま内容が更新される`() = runBlocking {
+        val remoteId = "web-uuid-2"
+        val localId = db.recordDao().insert(
+            ExaminationRecord(date = "2026-07-01", facility = "旧内容", createdAt = 500L, remoteId = remoteId)
+        )
+
+        cloudSync.recordsToReturn = listOf(
+            ExaminationRecord(id = 0, date = "2026-08-01", facility = "新内容", createdAt = 2000L, remoteId = remoteId) to
+                emptyList()
+        )
+        repository.restoreFromFirestore("shared-uid")
+
+        val all = db.recordDao().getAll().first()
+        assertEquals("突き合わせに失敗して新規行が作られてはならない", 1, all.size)
+        assertEquals(localId, all[0].id)
+        assertEquals("新内容", all[0].facility)
+    }
+
+    /**
+     * Issue #49 本文の再現シナリオそのもの:
+     * 「同じGoogleアカウントで2台のAndroid端末を使い、両方が端末ローカルで id=2 を採番しても、
+     *  Firestore上（本テストでは2つの HealthRepository インスタンスが共有する FakeSharedFirestore）
+     *  では別ドキュメントとして保存され、どちらの記録も消えない」ことを確認する。
+     */
+    @Test
+    fun `2台の端末がそれぞれローカルid2の記録を作ってもFirestore上は別ドキュメントになる`() = runBlocking {
+        // 端末A: 別々のRoom DBインスタンス（別端末を表す）
+        val dbA = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            HealthCheckupDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val repoA = HealthRepository(dbA, cloudSync, currentUidProvider = { "shared-uid" })
+
+        // 端末B
+        val dbB = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            HealthCheckupDatabase::class.java
+        ).allowMainThreadQueries().build()
+        val repoB = HealthRepository(dbB, cloudSync, currentUidProvider = { "shared-uid" })
+
+        try {
+            // 各端末で1件目を保存（端末ローカルid=1になる想定。前提の確認のみで本題ではない）
+            repoA.saveRecord("2026-08-01", "端末A・1件目", emptyList())
+            repoB.saveRecord("2026-08-02", "端末B・1件目", emptyList())
+
+            // 各端末で2件目を保存 → 両端末とも端末ローカルAUTOINCREMENTでid=2になる（衝突の前提）
+            val localIdA2 = repoA.saveRecord("2026-08-03", "端末A・2件目", emptyList())
+            val localIdB2 = repoB.saveRecord("2026-08-04", "端末B・2件目", emptyList())
+            assertEquals("前提: 端末Aの2件目は端末ローカルid=2", 2L, localIdA2)
+            assertEquals("前提: 端末Bの2件目も端末ローカルid=2（衝突の前提）", 2L, localIdB2)
+
+            // 修正前の実装（ドキュメントID = Roomのローカルid）なら、この時点で
+            // Firestore上は users/shared-uid/records/2 が後勝ちで1件しか残らず、データが消える。
+            // 修正後はremoteId（UUID）がドキュメントIDのため、4件とも別ドキュメントとして残るはず。
+            val allDocs = cloudSync.fetchRecords("shared-uid")
+            assertEquals(
+                "端末ローカルidが衝突していても、Firestore上のドキュメントは4件とも残らなければならない",
+                4,
+                allDocs.size
+            )
+
+            val remoteIdsUsed = allDocs.map { it.first.remoteId }
+            assertEquals("ドキュメントIDに重複があってはならない（=上書き衝突が起きている）", 4, remoteIdsUsed.toSet().size)
+
+            // 特に衝突の当事者だった「各端末の2件目」の記録が両方とも生き残っていること
+            val facilities = allDocs.map { it.first.facility }.toSet()
+            assertTrue(facilities.contains("端末A・2件目"))
+            assertTrue(facilities.contains("端末B・2件目"))
+
+            // 各端末が保存に使ったドキュメントIDそのものも異なること（衝突していた旧仕様との対比）
+            val recordA2 = dbA.recordDao().getById(localIdA2)!!
+            val recordB2 = dbB.recordDao().getById(localIdB2)!!
+            assertNotEquals(
+                "旧実装ではここが両方とも\"2\"になり衝突していた",
+                recordA2.remoteId,
+                recordB2.remoteId
+            )
+        } finally {
+            dbA.close()
+            dbB.close()
+        }
+    }
+
+    /**
+     * HealthCloudSync のフェイク実装。実際のFirestoreと同様、ドキュメントID（record.remoteId）を
+     * キーとしたMapへの `set()` 相当（完全上書き・mergeなし）で保存する。
+     * 複数の HealthRepository インスタンス（＝複数端末を表す）から同じインスタンスを共有させることで、
+     * 「Firestore上でドキュメントIDが衝突するかどうか」を検証できる。
+     */
+    private class FakeSharedFirestore : HealthCloudSync {
+        var recordsToReturn: List<Pair<ExaminationRecord, List<ExaminationItem>>> = emptyList()
+
+        // uid -> (remoteId -> 記録)。実際のFirestoreの `records` サブコレクションを模す。
+        private val store = mutableMapOf<String, MutableMap<String, Pair<ExaminationRecord, List<ExaminationItem>>>>()
+
+        override suspend fun saveRecord(uid: String, record: ExaminationRecord, items: List<ExaminationItem>) {
+            val bucket = store.getOrPut(uid) { mutableMapOf() }
+            // Firestoreの set()（mergeなし）を模す: 同じremoteId（ドキュメントID）への書き込みは完全上書きする
+            bucket[record.remoteId] = record to items
+        }
+
+        override suspend fun saveItemMaster(uid: String, master: ItemMaster) {
+            // 本テストでは未使用
+        }
+
+        override suspend fun fetchRecords(uid: String): List<Pair<ExaminationRecord, List<ExaminationItem>>> {
+            if (recordsToReturn.isNotEmpty()) return recordsToReturn
+            return store[uid]?.values?.toList() ?: emptyList()
+        }
+
+        override suspend fun fetchItemMasters(uid: String): List<ItemMaster> = emptyList()
+
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
+            store[uid]?.remove(remoteId)
+        }
+
+        override suspend fun deleteAllUserData(uid: String) {
+            store.remove(uid)
+        }
+    }
+}

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositorySignOutTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositorySignOutTest.kt
@@ -110,11 +110,21 @@ class HealthRepositorySignOutTest {
         repository.clearLocalDataOnSignOut()
 
         // Firestoreには記録とカスタマイズ済み項目マスターが保存されている想定
+        // Issue #49: 復元後の端末ローカルidはRoomのAUTOINCREMENTに委ねられる（サインアウト前に
+        // 別の記録が既に採番されているため、必ずしも1になるとは限らない）。そのため、
+        // フェッチ結果側の record.id ではなく remoteId（FirestoreドキュメントID）をキーに検証する。
+        val fetchedRemoteId = "web-record-1"
         cloudSync.recordsToReturn = listOf(
-            ExaminationRecord(id = 1L, date = "2026-08-01", facility = "六創堂クリニック", createdAt = 2000L) to
+            ExaminationRecord(
+                id = 0,
+                date = "2026-08-01",
+                facility = "六創堂クリニック",
+                createdAt = 2000L,
+                remoteId = fetchedRemoteId
+            ) to
                 listOf(
                     ExaminationItem(
-                        recordId = 1L,
+                        recordId = 0,
                         itemName = "LDLコレステロール",
                         value = "150",
                         unit = "mg/dL",
@@ -130,9 +140,10 @@ class HealthRepositorySignOutTest {
 
         repository.restoreFromFirestore("test-uid")
 
-        val restoredRecord = db.recordDao().getById(1L)
+        val restoredRecord = db.recordDao().getByRemoteId(fetchedRemoteId)
         assertTrue(restoredRecord != null)
         assertEquals("六創堂クリニック", restoredRecord!!.facility)
+        assertEquals(1, db.itemDao().getByRecordIdOnce(restoredRecord.id).size)
         val restoredMaster = db.masterDao().getByName("LDLコレステロール")
         assertTrue(restoredMaster != null)
         assertEquals(true, restoredMaster!!.isFavorite)
@@ -168,7 +179,7 @@ class HealthRepositorySignOutTest {
             return mastersToReturn
         }
 
-        override suspend fun deleteRecord(uid: String, recordId: Long) {
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
             // 本テストでは未使用（Issue #47）
         }
 

--- a/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryStartupResyncTest.kt
+++ b/android/app/src/test/java/com/rokusoudo/healthcheckup/data/repository/HealthRepositoryStartupResyncTest.kt
@@ -140,7 +140,7 @@ class HealthRepositoryStartupResyncTest {
             return mastersToReturn
         }
 
-        override suspend fun deleteRecord(uid: String, recordId: Long) {
+        override suspend fun deleteRecord(uid: String, remoteId: String) {
             // 本テストでは未使用（Issue #47）
         }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,13 @@
 - **Web**: Firestore を直接参照（ローカルキャッシュ不要、MVP段階）
 - **認証**: 両プラットフォームとも Firebase Auth（同一プロジェクト）でユーザーIDを共有
 - **データ分離**: Firestoreのパス `users/{uid}/records/{recordId}` でユーザーごとに分離
+  - **Issue #49（2026-09）**: `{recordId}` は Android の Room ローカルAUTOINCREMENT連番ではなく、
+    グローバルに一意な ID（Android: `ExaminationRecord.remoteId`＝UUID v4 / Web: `crypto.randomUUID()`）。
+    同じアカウントで複数端末を使うと端末ローカル連番が端末間で衝突し、`saveRecord()` の
+    `set()`（mergeなし）で片方の記録が上書き消失する不具合があったため変更した。
+    移行前に作成された既存ドキュメント（数値ID）は書き換えず、数値IDとUUIDが共存する
+    （一括移行は健診データの復旧困難リスクを避けるため行わない。
+    `HealthCheckupDatabase.MIGRATION_3_4` 参照）。
 
 ### フェーズ分割
 
@@ -193,10 +200,12 @@ flowchart TB
 
 ```
 ExaminationRecord（診断記録）
-├── id: Long (PK)
+├── id: Long (PK、端末ローカル。Room AUTOINCREMENT)
 ├── date: LocalDate（受診日）
 ├── facility: String（医療機関名、任意）
 ├── createdAt: Instant
+├── pushedToFirestore: Boolean（Firestoreへのpushが確認できているか。Issue #46）
+├── remoteId: String（UNIQUE。Firestoreドキュメント ID。UUID v4。Issue #49）
 └── [1:N] → ExaminationItem
 
 ExaminationItem（検査項目）
@@ -225,7 +234,7 @@ ItemMaster（項目マスター）
 
 ```
 users/{uid}/
-  ├── records/{recordId}/
+  ├── records/{recordId}/    ← recordId = remoteId（UUID v4。既存の数値IDドキュメントとは共存。Issue #49）
   │     ├── date: Timestamp
   │     ├── facility: String
   │     ├── createdAt: Timestamp

--- a/web/src/firestoreService.ts
+++ b/web/src/firestoreService.ts
@@ -36,7 +36,12 @@ export async function saveRecord(
   record: Omit<ExaminationRecord, 'id' | 'createdAt'>,
   existingId?: string,
 ): Promise<string> {
-  const id = existingId ?? String(Date.now())
+  // Issue #49: 新規記録のドキュメントIDはグローバルに一意なUUIDにする。
+  // 従来の Date.now()（13桁ミリ秒）は同時刻に近い操作で衝突しうる採番ではないが、
+  // Android側もRoomのローカル連番からUUID（remoteId）へ切り替えたため、プラットフォーム間で
+  // 採番方式を揃える（既存ドキュメントの一括書き換えは行わない。数値IDとUUIDは共存する）。
+  // createdAt の挙動（編集時にserverTimestamp()で上書きする点）は Issue #75 のスコープのため変更しない。
+  const id = existingId ?? crypto.randomUUID()
   await setDoc(doc(db, 'users', uid, 'records', id), {
     ...record,
     createdAt: serverTimestamp(),


### PR DESCRIPTION
Closes #49

## 背景・修正内容

Firestore の診断記録ドキュメント ID が、Android では Room の AUTOINCREMENT連番（`record.id.toString()`）、Web では `Date.now()` と端末・プラットフォームごとに別々の採番になっていた。同じ Google アカウントで Android 端末を2台使うと、両方の端末が独立に同じローカル連番（例: `id=2`）を採番し得るため、`FirestoreRepository.saveRecord()` の `set()`（mergeなし）で片方の健診記録が完全に上書きされ消失する不具合があった。

`ExaminationRecord` にグローバルに一意な `remoteId: String`（UUID v4）を追加し、Firestore ドキュメント ID・端末間の記録突き合わせキーとして使うことで、端末ローカルの `id`（Roomの主キー）と分離した。

## 実装内容

- **Room migration v3→v4（`MIGRATION_3_4`）**: `examination_records` に `remoteId` を追加し、UNIQUE インデックスを付与。既存行には `id.toString()` をそのまま投入する（既存 Firestore ドキュメントとの対応を壊さない）。
  - 本 Issue 起票時点では「v2→v3」の想定だったが、本日 Issue #46（PR #54）で `pushedToFirestore` 追加のため v2→v3 を先に使用済みだったため、v3→v4 として追加した。既存の `MIGRATION_1_2` / `MIGRATION_2_3` はそのまま維持し、`fallbackToDestructiveMigration` は使用していない。
- **`FirestoreRepository`**: `saveRecord()` / `fetchRecords()` / `deleteRecord()` のドキュメント ID を `record.remoteId` に切替。
  - `fetchRecords()` が `doc.id.toLongOrNull() ?: return@mapNotNull null` で非数値ドキュメントIDを黙って捨てていた実装を削除した。UUID導入後もこの判定を残すと、新形式（UUID）のドキュメントが fetch 結果から全て消え、Issue #46 の差分ミラー削除により他端末の新規記録がRoomから誤って削除されてしまうため、この修正は必須だった。
- **`HealthRepository.restoreFromFirestore()`**: 突き合わせキーを端末ローカル `id` から `remoteId` に変更。
  - `remoteId` が一致する既存ローカル行があれば、その行の端末ローカル `id` を維持したまま内容を `update()` する（新規追加した `ExaminationRecordDao.getByRemoteId()` / `update()`）。
  - 一致する行が無ければ新規挿入し、Room に端末ローカル `id` を新規採番させる。
  - **Issue #46 の差分ミラー削除との整合**: `deleteMirrored()` の判定キーも端末ローカル `id` から `remoteId` に変更した（`ExaminationRecordDao.deleteMirrored(keepRemoteIds: List<String>)`）。端末ローカル `id` のままでは、他端末の記録と数値が衝突した際に「Firestore側に存在するか」を正しく判定できず、誤削除につながるため。既存の `HealthRepositoryMirrorDeleteTest`（8ケース）はロジック変更なしで全てグリーン。
- **`HealthCloudSync.deleteRecord()`**: 引数を `recordId: Long` → `remoteId: String` に変更。フェイク実装6ファイル（`AccountDeletionManagerTest` / `HealthRepositoryDeleteTest` / `HealthRepositoryMirrorDeleteTest` / `HealthRepositoryRecalcTest` / `HealthRepositorySignOutTest` / `HealthRepositoryStartupResyncTest`）を全て追従済み。
  - `HealthRepository.deleteRecord()` は、対象記録がローカルに存在しない場合（`remoteId` を解決できない）は Firestore 削除を試みずローカル削除のみ行うよう変更した（従来は存在しないIDでも `recordId.toString()` で無条件に Firestore 削除を呼んでいた）。
- **Web (`web/src/firestoreService.ts`)**: 新規記録のドキュメント ID を `String(Date.now())` から `crypto.randomUUID()` に変更。`createdAt` を `serverTimestamp()` で上書きする既存挙動は変更していない（別 Issue #75 のスコープ）。
- **`docs/architecture.md`**: データパス記述・Roomエンティティ図・Firestoreデータモデル図を `remoteId` 導入後の内容に更新。

## 未解決の質問への回答（代表確認済み・2026-09-10、Issue本文に反映済み）

1. **既存の数値IDドキュメントの一括移行はしない。「既存は数値IDのまま・新規のみUUID」の共存方式を採用した。** 一括移行はFirestore上の全ドキュメントを読み直して新IDで書き直し旧IDを削除する操作になり、健診データに対して途中失敗が起きると復旧が困難なため。`remoteId` をキーにすれば、Android側の読み出し・突き合わせはID形式（数値/UUID）によらず統一的に扱える。
2. **Web側の `createdAt` 上書き問題（編集時に `serverTimestamp()` で上書きされる件）は本Issueでは扱わない。** 別Issue #75のスコープとし、`firestoreService.ts` の `saveRecord()` を触った際もこの挙動は変更していない。

## 既知の制約

- **既にドキュID衝突で上書き消失してしまった記録は、本PRでは復旧しない。** 移行時にローカルの `id` をそのまま `remoteId` として引き継ぐため、Firestore側で既に上書き負けしていた端末のローカル記録は、移行後最初の `restoreFromFirestore()` で勝者側の内容に更新される（＝挙動としては従来の `REPLACE` と同じで、今回のPRによる新たな劣化ではない）。本PRが防ぐのは「これから起きる」衝突であり、過去に発生済みの上書きは別途データ復旧の対象にはならない。

## テスト

- `./gradlew test`: 全162件グリーン（うち新規: `MigrationTest` に v3→v4 マイグレーションテスト1件追加、新規ファイル `HealthRepositoryRemoteIdSyncTest.kt` に3件追加）
  - v3→v4マイグレーションで既存行の `remoteId` に `id.toString()` が入ることを検証
  - `restoreFromFirestore()` が `remoteId` をキーに突き合わせ、同じ記録が二重にRoomへ入らないことを検証（同一fetch結果での2回連続復元、および既存ローカル行とのマージの両方）
  - **2台の端末がそれぞれ端末ローカル `id=2` の記録を作っても、Firestore上（共有のフェイク `HealthCloudSync`）では別ドキュメントとして残り、どちらの記録も消えないことを検証**（本Issueの再現シナリオそのものの回帰テスト）
  - 既存の `HealthRepositoryMirrorDeleteTest`（Issue #46）は無変更で全件グリーン
- `npm --prefix web run test -- --run`: 53件グリーン
- `npm --prefix web run lint`: 0 errors（既存の未関連warning1件のみ、本PRの変更対象外のファイル）
- `npm --prefix web run build`: 成功

## 未確認事項

- **実機・実ブラウザでの2台同時検証はこの環境では不可能なため未実施。** 上記の単体テスト（共有フェイク `HealthCloudSync` を使った2端末シミュレーション）でロジックレベルの検証は行ったが、実際のFirestore SDK・オフライン同期・実機2台での動作確認は代表側でのご確認をお願いします。

## その他

- ブランチは `origin/main`（PR #73マージ後の最新）から作成。
- PR #74（`fix/issue-51-web-custom-item-name`）が触っている `web/src/pages/RecordForm.tsx` / `web/src/lib/recordFormRow.*` には触れていない。
- Web側で `record.id` を数値として扱っている箇所（`Number()` / `parseInt()`）がないことも確認済み（`trend.ts` の日付パース、`recalcAbnormal.ts` の検査値パースのみで、ドキュメントIDとは無関係）。
